### PR TITLE
Add constraint docs

### DIFF
--- a/docs/src/jump.jl
+++ b/docs/src/jump.jl
@@ -3,7 +3,7 @@
 # ## JuMP to an ExaModel
 # We have an experimental interface to JuMP model. A JuMP model can be directly converted to a `ExaModel`. It is as simple as this:
 
-using ExaModels, JuMP, CUDA 
+using ExaModels, JuMP, CUDA
 
 N = 10
 jm = Model()

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -532,14 +532,21 @@ julia> x = variable(c, 10);
 
 julia> c1 = constraint(c, x[i] for i=1:9; lcon = -1, ucon = (1+i for i=1:9))
 
+This will add the following constraint to the model
+
+s.t. (...)
+g♭ ≤ [g(x,p)]_{p ∈ P} ≤ g♯
+
+where |P| = 9
+
 julia> constraint!(c, c1, x[i+1] for i=1:9)
 
-This will add the following onstraint to the model
+This will expand the existing constraint `c1` by incorporating the generators `x[i+1] for i=1:9` into the model
 
-  s.t. (...)
-       g♭ ≤ [g(x,p)]_{p ∈ P} ≤ g♯
+s.t. (...)
+    g♭ ≤ [g(x,p)]_{p ∈ P} ≤ g♯
 
-  where |P| = 9
+where |P| = 9
 ```
 """
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -511,6 +511,38 @@ function _constraint(c, f, pars, start, lcon, ucon)
     c.con = Constraint(c.con, f, convert_array(pars, c.backend), o)
 end
 
+"""
+    constraint!(c::C, c1, gen::Base.Generator) where {C<:ExaCore}
+
+Expands the existing constraint `c1` in `c` with additional constraints specified by a `generator`.
+If `generator` generates more constraints than originally present in `c1`, the new constraints will be added to the model, increasing the total number of constraints
+
+# Arguments
+- `c::C`: The model to which the constraints are added.
+- `c1`: An initial constraint value or expression.
+- `gen::Base.Generator`: A generator that produces the constraints to be added.
+
+## Example
+```jldoctest
+julia> using ExaModels
+
+julia> c = ExaCore();
+
+julia> x = variable(c, 10);
+
+julia> c1 = constraint(c, x[i] for i=1:9; lcon = -1, ucon = (1+i for i=1:9))
+
+julia> constraint!(c, c1, x[i+1] for i=1:9)
+
+This will add the following onstraint to the model
+
+  s.t. (...)
+       g♭ ≤ [g(x,p)]_{p ∈ P} ≤ g♯
+
+  where |P| = 9
+```
+"""
+
 function constraint!(c::C, c1, gen::Base.Generator) where {C<:ExaCore}
 
     gen = _adapt_gen(gen)
@@ -519,6 +551,12 @@ function constraint!(c::C, c1, gen::Base.Generator) where {C<:ExaCore}
 
     _constraint!(c, f, pars)
 end
+
+"""
+    constraint!(c, c1, expr, pars)
+
+Expands the existing constraint `c1` in `c` with addtional constraints specified by `expr` and `pars`.
+"""
 
 function constraint!(c::C, c1, expr, pars) where {C<:ExaCore}
     f = _simdfunction(expr, offset0(c1, 0), c.nnzj, c.nnzh)


### PR DESCRIPTION
I have added a docstring to the `constraint!` function in src/nlp.jl to provide documentation. The `constraint!` function previously lacked documentation, which made it harder for users and contributors to understand its purpose and usage. The new docstring explains the function's purpose and provides an example. This should help new users to understand how to use the function.