### PR TITLE
register asinh and acosh in default lib

### DIFF
--- a/src/functionlist.jl
+++ b/src/functionlist.jl
@@ -161,7 +161,9 @@
     x -> 57.29577951308232286464772187173366546630859375 * 2 * x / (1 + x^2)^2
 )
 @register_univariate(Base.sinh, cosh, sinh)
+@register_univariate(Base.asinh, x -> 1/sqrt(x^2 + 1), x -> - x/sqrt(x^2 + 1)^3)
 @register_univariate(Base.cosh, sinh, cosh)
+@register_univariate(Base.acosh, x -> 1/sqrt((x-1)*(x+1)), x -> - x/sqrt((x - 1)*(x + 1))^3)
 @register_univariate(Base.tanh, x -> 1 - tanh(x)^2, x -> -2 * tanh(x) * (1 - tanh(x)^2))
 @register_univariate(
     Base.csch,

--- a/test/ADTest/ADTest.jl
+++ b/test/ADTest/ADTest.jl
@@ -37,7 +37,9 @@ const FUNCTIONS = [
     # ("basic-functions-atand", x-> atand(x[1])), # cannot extend function 
     # ("basic-functions-acotd", x-> acotd(x[1])), # cannot extend function 
     ("basic-functions-sinh", x -> sinh(x[1])),
+    ("basic-functions-asinh", x -> asinh(x[1])),
     ("basic-functions-cosh", x -> cosh(x[1])),
+    ("basic-functions-acosh", x -> acosh(x[1] + 1)),
     ("basic-functions-tanh", x -> tanh(x[1])),
     ("basic-functions-csch", x -> csch(x[1])),
     ("basic-functions-sech", x -> sech(x[1])),


### PR DESCRIPTION
Hey!

I needed `asinh` and thought it belonged (alongside `acosh`) into the default lib of supported functions.

Flemming 