### PR TITLE
minor fix (?) in quadrotor example

### DIFF
--- a/docs/src/quad.jl
+++ b/docs/src/quad.jl
@@ -4,12 +4,11 @@ function quadrotor_model(N = 3; backend = nothing)
 
     n = 9
     p = 4
-    nd = 9
     d(i, j, N) =
         (j == 1 ? 1 * sin(2 * pi / N * i) : 0.0) +
         (j == 3 ? 2 * sin(4 * pi / N * i) : 0.0) +
         (j == 5 ? 2 * i / N : 0.0)
-    dt = 0.01
+    dt = 1/N
     R = fill(1 / 10, 4)
     Q = [1, 0, 1, 0, 1, 0, 1, 1, 1]
     Qf = [1, 0, 1, 0, 1, 0, 1, 1, 1] / dt


### PR DESCRIPTION
hi @sshin23 just to fix what looks like a (very) minor issue as `dt` should `T/N` (or `1/N`, depending in any case on `N` as, otherwise, changing the grid size implies changing the time horizon)

BTW: the mayer term in the cost is a bit strange (just looks like the reweighted final grid point of the Lagrange quadrature, but for the control):

```julia
    objective(c, 0.5 * Qf * (x[N+1, j] - d)^2 for (j, Qf, d) in itr2)
```

do you have a detailed ref. towards the problem?

cc: @amontoison 