### PR TITLE
Update MOI extension

### DIFF
--- a/ext/ExaModelsJuMP.jl
+++ b/ext/ExaModelsJuMP.jl
@@ -4,7 +4,7 @@ import ExaModels
 import JuMP
 
 function ExaModels.ExaModel(jm::JuMP.GenericModel{T}; options...) where {T}
-    return ExaModels.ExaModel(jm.moi_backend.model_cache; options...)
+    return ExaModels.ExaModel(JuMP.backend(jm); options...)
 end
 
 end # module ExaModelsJuMP

--- a/ext/ExaModelsJuMP.jl
+++ b/ext/ExaModelsJuMP.jl
@@ -4,7 +4,6 @@ import ExaModels
 import JuMP
 
 function ExaModels.ExaModel(jm::JuMP.GenericModel{T}; options...) where {T}
-    # FIXME: what is user passes `T` under `options`?
     return ExaModels.ExaModel(JuMP.backend(jm); T=T, options...)
 end
 

--- a/ext/ExaModelsJuMP.jl
+++ b/ext/ExaModelsJuMP.jl
@@ -4,7 +4,8 @@ import ExaModels
 import JuMP
 
 function ExaModels.ExaModel(jm::JuMP.GenericModel{T}; options...) where {T}
-    return ExaModels.ExaModel(JuMP.backend(jm); options...)
+    # FIXME: what is user passes `T` under `options`?
+    return ExaModels.ExaModel(JuMP.backend(jm); T=T, options...)
 end
 
 end # module ExaModelsJuMP

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -168,6 +168,7 @@ function copy_constraints!(c, moim, var_to_idx, T)
         for S in SUPPORTED_SET_TYPE
             ST = S{T}
             cis = MOI.get(moim, MOI.ListOfConstraintIndices{FT,ST}())
+            isempty(cis) && continue
             bin, offset = exafy_con(moim, cis, bin, offset, lcon, ucon, y0, var_to_idx, con_to_idx)
         end
     end

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -255,7 +255,6 @@ function _exafy_con(i, c::C, bin, var_to_idx, con_to_idx; pos = true) where {C<:
         -ExaModels.ParIndexed(ExaModels.ParSource(), 1)
     bin = update_bin!(
         bin,
-        # FIXME: why do we need 0x1 here?
         ExaModels.ParIndexed(ExaModels.ParSource(), 2) => 0 * ExaModels.Var(1) + e,
         (c, con_to_idx[i]),
     )

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -143,7 +143,7 @@ function copy_objective!(c, moim, var_to_idx)
     build_objective!(c, obj_bin)
 end
 
-function ExaModels.ExaModel(moim::MOI.ModelLike; backend = nothing, prod = false)
+function ExaModels.ExaModel(moim::MOI.ModelLike; backend = nothing, prod = false, return_maps = false)
     minimize = MOI.get(moim, MOI.ObjectiveSense()) === MOI.MIN_SENSE
     variables = MOI.get(moim, MOI.ListOfVariableIndices())
     con_types = MOI.get(moim, MOI.ListOfConstraintTypesPresent())
@@ -164,7 +164,11 @@ function ExaModels.ExaModel(moim::MOI.ModelLike; backend = nothing, prod = false
     con_to_idx = copy_constraints!(c, moim, var_to_idx, T)
     copy_objective!(c, moim, var_to_idx)
 
-    return ExaModels.ExaModel(c; prod = prod), (var_to_idx, con_to_idx)
+    if return_maps
+        return ExaModels.ExaModel(c; prod = prod), (var_to_idx, con_to_idx)
+    else
+        return ExaModels.ExaModel(c; prod = prod)
+    end
 end
 
 function _exafy_con(i, c::C, bin, var_to_idx, con_to_idx; pos = true) where {C<:MOI.ScalarAffineFunction}
@@ -561,7 +565,7 @@ function MOI.empty!(model::ExaModelsMOI.Optimizer)
 end
 
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
-    dest.model, maps = ExaModels.ExaModel(src; backend = dest.backend)
+    dest.model, maps = ExaModels.ExaModel(src; backend = dest.backend, return_maps = true)
     return _make_index_map(src, maps)
 end
 

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -688,9 +688,9 @@ function _make_index_map(model::MOI.ModelLike, var_to_idx, con_to_idx)
     variables = MOI.get(model, MOI.ListOfVariableIndices())
     map = MOI.Utilities.IndexMap()
     for x in variables
-        map[x] = var_to_idx[x]
+        map[x] = typeof(x)(var_to_idx[x])
     end
-    for (F, S) in MOI.get(model, MOI.Utilities.ListOfConstraintTypesPresent())
+    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
         _make_constraints_map(model, map.con_map[F, S], con_to_idx)
     end
     return map
@@ -701,7 +701,7 @@ function _make_constraints_map(
     con_to_idx
 ) where {F,S}
     for c in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-        map[c] = con_to_idx[c]
+        map[c] = typeof(c)(con_to_idx[c])
     end
     return
 end

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -186,7 +186,6 @@ function copy_constraints!(c, moim, var_to_idx, T)
     for (F,S) in con_types
         F <: MOI.VariableIndex && continue
         cis = MOI.get(moim, MOI.ListOfConstraintIndices{F,S}())
-        isempty(cis) && continue
         bin, offset = exafy_con(moim, cis, bin, offset, lcon, ucon, y0, var_to_idx, con_to_idx)
     end
     cons = ExaModels.constraint(c, offset; start = y0, lcon = lcon, ucon = ucon)
@@ -359,7 +358,7 @@ function exafy_obj(o::MOI.ScalarNonlinearFunction, bin, var_to_idx)
     if o.head == :+
         for m in o.args
             if m isa MOI.ScalarAffineFunction
-                for mm in m.affine_terms
+                for mm in m.terms
                     e, p = _exafy(mm, var_to_idx)
                     bin = update_bin!(bin, e, p)
                 end

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -591,7 +591,7 @@ function MOI.supports_constraint(
 end
 function MOI.supports(
     ::Optimizer,
-    ::MOI.ObjectiveFunction{SUPPORTED_FUNC_TYPE_WITH_VAR},
+    ::MOI.ObjectiveFunction{<:SUPPORTED_FUNC_TYPE_WITH_VAR},
 )
     return true
 end

--- a/test/JuMPTest/JuMPTest.jl
+++ b/test/JuMPTest/JuMPTest.jl
@@ -60,22 +60,22 @@ function fixed_variable_e2etest()
     JuMP.@constraint(jm, sum(x) == p)
     JuMP.@objective(jm, Min, sum(x))
 
-    @test_broken em = ExaModel(jm) # FIXME: merge #158
-    # @test only(em.meta.lcon) == only(em.meta.ucon) == 0.0
-    # @test only(em.θ) == 1.0
-    # wcons = em.cons
-    # @test typeof(wcons) <: ExaModels.ConstraintAug
-    # @test typeof(wcons.f.f) <: ExaModels.Null
-    # cons = wcons.inner
-    # @test typeof(cons) <: ExaModels.ConstraintAug
-    # @test typeof(cons.f.f) <: Pair
-    # @test typeof(cons.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.ParameterNode{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
-    # @test typeof(cons.inner) <: ExaModels.ConstraintAug
-    # @test typeof(cons.inner.f.f) <: Pair
-    # @test typeof(cons.inner.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.Var{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
-    # @test typeof(cons.inner.inner) <: ExaModels.Constraint
-    # @test typeof(cons.inner.inner.f.f) <: ExaModels.Null{Nothing}
-    # @test typeof(cons.inner.inner.inner) <: ExaModels.ConstraintNull
+    em = ExaModel(jm)
+    @test only(em.meta.lcon) == only(em.meta.ucon) == 0.0
+    @test only(em.θ) == 1.0
+    wcons = em.cons
+    @test typeof(wcons) <: ExaModels.ConstraintAug
+    @test typeof(wcons.f.f) <: ExaModels.Null
+    cons = wcons.inner
+    @test typeof(cons) <: ExaModels.ConstraintAug
+    @test typeof(cons.f.f) <: Pair
+    @test typeof(cons.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.ParameterNode{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    @test typeof(cons.inner) <: ExaModels.ConstraintAug
+    @test typeof(cons.inner.f.f) <: Pair
+    @test typeof(cons.inner.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.Var{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    @test typeof(cons.inner.inner) <: ExaModels.Constraint
+    @test typeof(cons.inner.inner.f.f) <: ExaModels.Null{Nothing}
+    @test typeof(cons.inner.inner.inner) <: ExaModels.ConstraintNull
 
     jm = JuMP.Model()
     JuMP.@variable(jm, x)

--- a/test/JuMPTest/JuMPTest.jl
+++ b/test/JuMPTest/JuMPTest.jl
@@ -174,7 +174,7 @@ function runtests()
 
                     for backend in BACKENDS
                         @testset "$backend" begin
-                            m = WrapperNLPModel(first(ExaModel(jm; backend = backend)))
+                            m = WrapperNLPModel(ExaModel(jm; backend = backend))
                             result = ipopt(m; print_level = 0)
 
                             @test sol ≈ result.solution atol = 1e-6

--- a/test/JuMPTest/JuMPTest.jl
+++ b/test/JuMPTest/JuMPTest.jl
@@ -23,6 +23,106 @@ function jump_luksan_vlcek_model(N)
 
     return jm
 end
+function fixed_variable_e2etest()
+    N=5
+    jm = JuMP.Model()
+
+    JuMP.@variable(jm, x[1:N])
+    JuMP.fix(x[1], 1.0)
+    JuMP.@constraint(jm, sum(x) == 1.0)
+    JuMP.@objective(jm, Min, sum(2*x[i]^2 for i in 1:N))
+
+    em = ExaModel(jm)
+    @test only(em.meta.lcon) == only(em.meta.ucon) == 1.0
+
+    # FIXME: two ConstraintAug?
+    wcons = em.cons
+    @test typeof(wcons) <: ExaModels.ConstraintAug
+    @test typeof(wcons.f.f) <: ExaModels.Null
+
+    cons = wcons.inner
+    @test typeof(cons) <: ExaModels.ConstraintAug
+    @test typeof(cons.f.f) <: Pair
+
+    @test typeof(cons.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.Var{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+
+    @test typeof(cons.inner) <: ExaModels.Constraint
+    @test typeof(cons.inner.f.f) <: ExaModels.Null{Nothing}
+    @test typeof(cons.inner.inner) <: ExaModels.ConstraintNull
+
+    @test typeof(em.objs.f.f) <: ExaModels.Null
+    @test typeof(em.objs.inner.f.f) <: ExaModels.Node2{typeof(*), T1, ExaModels.Node1{typeof(abs2), ExaModels.Var{T2}}} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+
+    jm = JuMP.Model()
+
+    JuMP.@variable(jm, x[1:N])
+    JuMP.@variable(jm, p in JuMP.Parameter(1.0))
+    JuMP.@constraint(jm, sum(x) == p)
+    JuMP.@objective(jm, Min, sum(x))
+
+    @test_broken em = ExaModel(jm) # FIXME: merge #158
+    # @test only(em.meta.lcon) == only(em.meta.ucon) == 0.0
+    # @test only(em.θ) == 1.0
+    # wcons = em.cons
+    # @test typeof(wcons) <: ExaModels.ConstraintAug
+    # @test typeof(wcons.f.f) <: ExaModels.Null
+    # cons = wcons.inner
+    # @test typeof(cons) <: ExaModels.ConstraintAug
+    # @test typeof(cons.f.f) <: Pair
+    # @test typeof(cons.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.ParameterNode{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    # @test typeof(cons.inner) <: ExaModels.ConstraintAug
+    # @test typeof(cons.inner.f.f) <: Pair
+    # @test typeof(cons.inner.f.f.second) <: ExaModels.Node2{typeof(*), ExaModels.Var{T1}, T2} where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    # @test typeof(cons.inner.inner) <: ExaModels.Constraint
+    # @test typeof(cons.inner.inner.f.f) <: ExaModels.Null{Nothing}
+    # @test typeof(cons.inner.inner.inner) <: ExaModels.ConstraintNull
+
+    jm = JuMP.Model()
+    JuMP.@variable(jm, x)
+    @test_broken em = ExaModel(jm)  # FIXME: support feasibility problems?
+
+    return jm
+end
+function no_constraints_e2etest()
+    N=5
+    jm = JuMP.Model()
+    JuMP.@variable(jm, x[1:N])
+    JuMP.@objective(jm, Max, sum(sin(x[i]) for i in 1:N))
+
+    em = ExaModel(jm)
+
+    @test typeof(em.cons) <: ExaModels.Constraint
+    @test typeof(em.cons.inner) <: ExaModels.ConstraintNull
+
+    @test typeof(em.objs.f.f) <: ExaModels.Null
+    @test typeof(em.objs.inner.f.f) <: ExaModels.Node1{typeof(sin), ExaModels.Var{T1}} where {T1<:ExaModels.ParIndexed}
+
+    N=5
+    jm = JuMP.Model()
+    JuMP.@variable(jm, x[1:N])
+    JuMP.@objective(jm, Max, sin(sum(x[i] for i in 1:N)))
+
+    em = ExaModel(jm)
+
+    @test typeof(em.cons) <: ExaModels.Constraint
+    @test typeof(em.cons.inner) <: ExaModels.ConstraintNull
+
+    @test typeof(em.objs.f.f) <: ExaModels.Null
+    # broken since ExaMOI fails to detect SIMD in this case
+    @test_broken typeof(em.objs.inner.f.f) <: ExaModels.Node1{typeof(sin), ExaModels.Var{T1}} where {T1}
+end
+function generic_e2etest()
+    N=5
+    jm = JuMP.GenericModel{Float32}()
+    JuMP.@variable(jm, x[1:N])
+    JuMP.@constraint(jm, sum(x) == 1.0f0)
+    JuMP.@objective(jm, Min, sum(x[i]^2 for i in 1:N))
+
+    em = ExaModel(jm)
+    
+    @test typeof(em) <: ExaModel{Float32}
+    @test typeof(getindex.(em.cons.inner.itr, 2)) <: Vector{Float32}
+end
 
 function jump_ac_power_model(filename = "pglib_opf_case3_lmbd.m")
 
@@ -32,6 +132,7 @@ function jump_ac_power_model(filename = "pglib_opf_case3_lmbd.m")
     #JuMP.set_optimizer_attribute(model, "print_level", 0)
 
     JuMP.@variable(model, va[i in keys(ref[:bus])])
+    JuMP.@variable(model, will_delete)
     JuMP.@variable(
         model,
         ref[:bus][i]["vmin"] <= vm[i in keys(ref[:bus])] <= ref[:bus][i]["vmax"],
@@ -155,6 +256,8 @@ function jump_ac_power_model(filename = "pglib_opf_case3_lmbd.m")
         JuMP.@constraint(model, p_to^2 + q_to^2 <= branch["rate_a"]^2)
     end
 
+    JuMP.delete(model, will_delete)
+
     return model
 end
 
@@ -182,6 +285,11 @@ function runtests()
                     end
                 end
             end
+        end
+        @testset "E2E tests" begin
+            generic_e2etest()
+            fixed_variable_e2etest()
+            no_constraints_e2etest()
         end
     end
 end

--- a/test/JuMPTest/JuMPTest.jl
+++ b/test/JuMPTest/JuMPTest.jl
@@ -174,7 +174,7 @@ function runtests()
 
                     for backend in BACKENDS
                         @testset "$backend" begin
-                            m = WrapperNLPModel(ExaModel(jm; backend = backend))
+                            m = WrapperNLPModel(first(ExaModel(jm; backend = backend)))
                             result = ipopt(m; print_level = 0)
 
                             @test sol ≈ result.solution atol = 1e-6


### PR DESCRIPTION
This PR updates `ExaModelsMOI` to use MOI safely. Closes #100, closes #130

Future work:
- Optimize the speed of conversion (function barriers?)
- Consider allowing to convert float type
- Consider supporting manual binning [ref](https://github.com/exanauts/ExaModels.jl/issues/132#issuecomment-2773026512)
- Consider implementing `MOI.Nonlinear.Evaluator` [ref](https://github.com/exanauts/ExaModels.jl/issues/132#issuecomment-2773404302)
- Better SIMD detection for nonlinear expressions (even basic ones like $\\ \sin(\sum_{i} x_{i})$ currently get flattened to $\sin(x_1+x_2+\cdots+x_n)$
- Detect easy cases like $\sum_{i} 1.0 * x_i\enspace\rightarrow\enspace\sum_{i} x_i\enspace$ or $\enspace 0.0 + \sum_{i} x_i\enspace\rightarrow\enspace\sum_{i} x_i$