### PR TITLE
Fix nesting structs in generators.

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -117,6 +117,10 @@ end
 @inline Base.getindex(n::ParSource, i) = ParIndexed(n, i)
 @inline Base.indexed_iterate(n::ParSource, idx, start = 1) = (ParIndexed(n, idx), idx + 1)
 
+@inline Base.getproperty(v::ParIndexed{I, n}, s::Symbol) where {I, n} = ParIndexed(v, s)
+@inline Base.getindex(v::ParIndexed{I, n}, i) where {I, n} = ParIndexed(v, i)
+@inline Base.indexed_iterate(v::ParIndexed{I, n}, idx, start = 1) where {I, n} = (ParIndexed(v, idx), idx + 1)
+
 
 @inline Base.getindex(n::VarSource, i) = Var(i)
 @inline Base.getindex(::ParameterSource, i) = ParameterNode(i)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -144,7 +144,7 @@ struct Identity end
 @inline (v::ParameterNode{I})(::Identity, x, ::Nothing) where {I<:AbstractNode} = NaN
 
 @inline (v::ParSource)(i, x, θ) = i
-@inline (v::ParIndexed{I,n})(i, x, θ) where {I,n} = @inbounds getfield(v.inner(i, x, θ), n)
+@inline (v::ParIndexed{I,n})(i, x, θ) where {I,n} = @inbounds getfield(getfield(v, :inner)(i, x, θ), n)
 
 (v::ParIndexed)(i::Identity, x, θ) = NaN # despecialized
 (v::ParSource)(i::Identity, x, θ) = NaN # despecialized


### PR DESCRIPTION
This pr allows nesting of structures in generators passed to constraint, objective, etc. the following sample is fixed by the pr:
```julia
struct A
    foo::Int
end
core = ExaCore(Float64; backend = nothing)
v = variable(core, 1)
a = [A(1)]
c = constraint(core, v[i] < i * a.foo for (i, a) in enumerate(a)) # previously would error here, with no method indexed_iterate for ParIndexed
```