### PR TITLE
Support for ObjectiveSense

### DIFF
--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -700,6 +700,9 @@ function MOI.supports_constraint(
 )
     return true
 end
+function MOI.supports(::Optimizer, ::MOI.ObjectiveSense)
+    return true
+end
 function MOI.supports(::Optimizer, ::MOI.ObjectiveFunction{<:SUPPORTED_FUNC_TYPE_WITH_VAR})
     return true
 end


### PR DESCRIPTION
Otherwise I get an error when changing the objective function as it think the issue is that `ObjectiveSense` is not supported, not that the model should be wiped out and `copy_to` should be called again