### PR TITLE
Add POCL extension

### DIFF
--- a/ext/ExaModelsPOCL.jl
+++ b/ext/ExaModelsPOCL.jl
@@ -1,0 +1,8 @@
+module ExaModelsPOCL
+
+import ExaModels: ExaModels, NLPModels
+import KernelAbstractions: POCL, POCLBackend
+
+ExaModels.convert_array(v, backend::POCLBackend) = Array(v)
+
+end

--- a/test/backends.jl
+++ b/test/backends.jl
@@ -1,4 +1,4 @@
-const BACKENDS = Any[nothing, CPU()]
+const BACKENDS = Any[nothing, CPU(), POCLBackend()]
 
 if haskey(ENV, "EXAMODELS_TEST_CUDA")
     using CUDA


### PR DESCRIPTION
POCL is included by default in KernelAbstractions. It performs better than `CPU()` and I think it will become the default backend.