### PR TITLE
Throws an error when legacy JuMP model is used

### DIFF
--- a/ext/ExaModelsJuMP.jl
+++ b/ext/ExaModelsJuMP.jl
@@ -4,6 +4,10 @@ import ExaModels
 import JuMP
 
 function ExaModels.ExaModel(jm::JuMP.GenericModel{T}; options...) where {T}
+    if JuMP.nonlinear_model(jm) != nothing
+        error("The legacy nonlinear model interface is not supported. Please use the new MOI-based interface.")
+    end
+    
     return ExaModels.ExaModel(JuMP.backend(jm); T = T, options...)
 end
 

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -77,7 +77,8 @@ function ExaModels.ExaModel(
     backend = nothing,
     prod = false,
     T = Float64,
-)
+    )
+
     c, _ = to_exacore(moim; backend = backend, T = T)
     return ExaModels.ExaModel(c; prod = prod)
 end
@@ -721,6 +722,7 @@ end
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
     core, maps = to_exacore(src; backend = dest.backend)
     dest.model = ExaModels.ExaModel(core; prod = true)
+
     return _make_index_map(src, maps)
 end
 
@@ -851,6 +853,10 @@ function _make_constraints_map(
         map[c] = typeof(c)(con_to_idx[c])
     end
     return
+end
+
+function MOI.set(model::Optimizer, ::MOI.NLPBlock, nlp_data::MOI.NLPBlockData)
+    error("The legacy nonlinear model interface is not supported. Please use the new MOI-based interface.")
 end
 
 end # module

--- a/test/JuMPTest/JuMPTest.jl
+++ b/test/JuMPTest/JuMPTest.jl
@@ -23,6 +23,19 @@ function jump_luksan_vlcek_model(N)
 
     return jm
 end
+
+function nlp_legacy_runtests()
+    jm = JuMP.Model()
+
+    JuMP.@variable(jm, x[1:10])
+    JuMP.@NLobjective(jm, Min, sum(x[i] for i=1:10))
+
+    @test_throws ErrorException ExaModel(jm)
+
+    jm = JuMP.Model(() -> ExaModels.Optimizer(NLPModelsIpopt.ipopt))
+    @test_throws ErrorException optimize!(jm)
+end
+    
 function fixed_variable_e2etest()
     N=5
     jm = JuMP.Model()
@@ -308,6 +321,9 @@ function runtests()
             generic_e2etest()
             fixed_variable_e2etest()
             no_constraints_e2etest()
+        end
+        @testset "NLP legacy test" begin
+            nlp_legacy_runtests()
         end
     end
 end


### PR DESCRIPTION
closes #198 
cc: @klamike @odow