### PR TITLE
Cancel branch workflows after push on branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   github:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Yesterday, the CI was on fire. Mainly my fault (oneAPI and pushes), but I saw the release branch getting delayed. I sometimes do a lot of pushs. This cancels all past jobs on that branch if a new commit comes in. 