### PR TITLE
Change naming convention: Par → Data

### DIFF
--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -237,7 +237,7 @@ function _exafy_con(
         e = pos ? e : -e
         bin = update_bin!(
             bin,
-            ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1) => e,
+            ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1) => e,
             (p..., con_to_idx[i]),
         ) # augment data with constraint index
     end
@@ -257,7 +257,7 @@ function _exafy_con(
         e = pos ? e : -e
         bin = update_bin!(
             bin,
-            ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1) => e,
+            ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1) => e,
             (p..., con_to_idx[i]),
         ) # augment data with constraint index
     end
@@ -266,7 +266,7 @@ function _exafy_con(
         e = pos ? e : -e
         bin = update_bin!(
             bin,
-            ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1) => e,
+            ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1) => e,
             (p..., con_to_idx[i]),
         ) # augment data with constraint index
     end
@@ -293,7 +293,7 @@ function _exafy_con(
         e = pos ? e : -e
         bin = update_bin!(
             bin,
-            ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1) => e,
+            ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1) => e,
             (p..., con_to_idx[i]),
         ) # augment data with constraint index
     end
@@ -301,11 +301,11 @@ function _exafy_con(
 end
 function _exafy_con(i, c::C, bin, var_to_idx, con_to_idx; pos = true) where {C<:Real}
     e =
-        pos ? ExaModels.ParIndexed(ExaModels.ParSource(), 1) :
-        -ExaModels.ParIndexed(ExaModels.ParSource(), 1)
+        pos ? ExaModels.DataIndexed(ExaModels.DataSource(), 1) :
+        -ExaModels.DataIndexed(ExaModels.DataSource(), 1)
     bin = update_bin!(
         bin,
-        ExaModels.ParIndexed(ExaModels.ParSource(), 2) => 0 * ExaModels.Var(1) + e,
+        ExaModels.DataIndexed(ExaModels.DataSource(), 2) => 0 * ExaModels.Var(1) + e,
         (c, con_to_idx[i]),
     )
 
@@ -465,7 +465,7 @@ function exafy_obj(o::MOI.ScalarNonlinearFunction, bin, var_to_idx)
 end
 
 function _exafy(v::MOI.VariableIndex, var_to_idx, p = ())
-    i = ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1)
+    i = ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
     vartype, idx = var_to_idx[v]
     if vartype === :variable
         return ExaModels.Var(i), (p..., idx)
@@ -477,7 +477,7 @@ function _exafy(v::MOI.VariableIndex, var_to_idx, p = ())
 end
 
 function _exafy(i::R, var_to_idx, p) where {R<:Real}
-    return ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1), (p..., i)
+    return ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1), (p..., i)
 end
 
 function _exafy(e::MOI.ScalarNonlinearFunction, var_to_idx, p = ())
@@ -493,9 +493,9 @@ function _exafy(e::MOI.ScalarAffineFunction{T}, var_to_idx, p = ()) where {T}
             c1, p = _exafy(term, var_to_idx, p)
             c1
         end for term in e.terms) +
-        ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1)
+        ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
     else
-        ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1)
+        ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
     end
 
     return ec, (p..., e.constant)
@@ -503,12 +503,12 @@ end
 
 function _exafy(e::MOI.ScalarAffineTerm{T}, var_to_idx, p = ()) where {T}
     c1, p = _exafy(e.variable, var_to_idx, p)
-    return *(c1, ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1)),
+    return *(c1, ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)),
     (p..., e.coefficient)
 end
 
 function _exafy(e::MOI.ScalarQuadraticFunction{T}, var_to_idx, p = ()) where {T}
-    t = ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1)
+    t = ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
     p = (p..., e.constant)
 
     if !isempty(e.affine_terms)
@@ -532,12 +532,12 @@ function _exafy(e::MOI.ScalarQuadraticTerm{T}, var_to_idx, p = ()) where {T}
 
     if e.variable_1 == e.variable_2
         v, p = _exafy(e.variable_1, var_to_idx, p)
-        return ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1) * abs2(v),
+        return ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1) * abs2(v),
         (p..., e.coefficient / 2) # it seems that MOI assumes this by default
     else
         v1, p = _exafy(e.variable_1, var_to_idx, p)
         v2, p = _exafy(e.variable_2, var_to_idx, p)
-        return ExaModels.ParIndexed(ExaModels.ParSource(), length(p) + 1) * v1 * v2,
+        return ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1) * v1 * v2,
         (p..., e.coefficient)
     end
 end

--- a/ext/ExaModelsMOI.jl
+++ b/ext/ExaModelsMOI.jl
@@ -493,7 +493,7 @@ function _exafy(e::MOI.ScalarAffineFunction{T}, var_to_idx, p = ()) where {T}
             c1, p = _exafy(term, var_to_idx, p)
             c1
         end for term in e.terms) +
-        ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
+            ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
     else
         ExaModels.DataIndexed(ExaModels.DataSource(), length(p) + 1)
     end

--- a/src/ExaModels.jl
+++ b/src/ExaModels.jl
@@ -8,7 +8,7 @@ for SIMD-parallel evaluation of nonlinear programs on CPUs and GPUs.
 
 Expressions are represented as trees of [`AbstractNode`](@ref) subtypes:
 
-- [`Var`](@ref) / [`ParIndexed`](@ref) — decision variables and data fields
+- [`Var`](@ref) / [`DataIndexed`](@ref) — decision variables and data fields
 - [`Node1`](@ref) / [`Node2`](@ref) — unary / binary operations
 - [`Constant{T}`](@ref) — compile-time scalar constant; the value `T` is
   stored as a **type parameter** so it is visible to the compiler and to

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -68,7 +68,7 @@ Performs dsparse gradient evaluation via the reverse pass on the computation (su
     o1,
     cnt,
     adj,
-) where {D<:Union{AdjointNull,ParIndexed,Real}}
+) where {D<:Union{AdjointNull,DataIndexed,Real}}
     return cnt
 end
 @inline function grpass(d::D, comp, y, o1, cnt, adj) where {D<:AdjointNode1}
@@ -104,7 +104,7 @@ end
     o1,
     cnt::Tuple{<:Tuple,<:Tuple},
     adj,
-) where {D<:Union{AdjointNull,ParIndexed,Real}}
+) where {D<:Union{AdjointNull,DataIndexed,Real}}
     return cnt
 end
 @inline function grpass(

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -68,7 +68,7 @@ Performs dsparse gradient evaluation via the reverse pass on the computation (su
     o1,
     cnt,
     adj,
-) where {D<:Union{AdjointNull,DataIndexed,Real}}
+    ) where {D <: Union{AdjointNull, DataIndexed, Real}}
     return cnt
 end
 @inline function grpass(d::D, comp, y, o1, cnt, adj) where {D<:AdjointNode1}
@@ -102,9 +102,9 @@ end
     comp::Nothing,
     y,
     o1,
-    cnt::Tuple{<:Tuple,<:Tuple},
+    cnt::Tuple{<:Tuple, <:Tuple},
     adj,
-) where {D<:Union{AdjointNull,DataIndexed,Real}}
+    ) where {D <: Union{AdjointNull, DataIndexed, Real}}
     return cnt
 end
 @inline function grpass(

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -163,12 +163,12 @@ parameter so that `getfield` / `getindex` can be resolved at compile time.
 
 Constructed implicitly via `getproperty` / `getindex` on a [`DataSource`](@ref).
 """
-struct DataIndexed{I,J} <: AbstractNode
+struct DataIndexed{I, J} <: AbstractNode
     inner::I
 end
 
-@inline DataIndexed(inner::I, n) where {I} = DataIndexed{I,n}(inner)
-@inline DataIndexed(inner::I, s::Constant{n}) where {I,n} = DataIndexed{I,n}(inner)
+@inline DataIndexed(inner::I, n) where {I} = DataIndexed{I, n}(inner)
+@inline DataIndexed(inner::I, s::Constant{n}) where {I, n} = DataIndexed{I, n}(inner)
 """
     Node1{F, I} <: AbstractNode
 
@@ -210,7 +210,7 @@ end
 
 @inline Base.getproperty(n::DataSource, s::Symbol) = DataIndexed(n, s)
 @inline Base.getindex(n::DataSource, i) = DataIndexed(n, i)
-@inline Base.indexed_iterate(n::P, idx, start = 1) where P <: Union{DataSource, DataIndexed} = (DataIndexed(n, idx), idx + 1)
+@inline Base.indexed_iterate(n::P, idx, start = 1) where {P <: Union{DataSource, DataIndexed}} = (DataIndexed(n, idx), idx + 1)
 
 @inline Base.getproperty(v::DataIndexed{I, n}, s::Symbol) where {I, n} = DataIndexed(v, s)
 @inline Base.getindex(v::DataIndexed{I, n}, i) where {I, n} = DataIndexed(v, i)
@@ -236,7 +236,7 @@ struct Identity end
 @inline (v::ParameterNode{I})(::Identity, x, θ) where {I<:AbstractNode} = @inbounds θ[v.i]
 
 @inline (v::DataSource)(i, x, θ) = i
-@inline (v::DataIndexed{I,n})(i, x, θ) where {I,n} = @inbounds getfield(getfield(v, :inner)(i, x, θ), n)
+@inline (v::DataIndexed{I, n})(i, x, θ) where {I, n} = @inbounds getfield(getfield(v, :inner)(i, x, θ), n)
 
 @inline (v::DataIndexed)(i::Identity, x, θ) = eltype(θ)(NaN)
 @inline (v::DataSource)(i::Identity, x, θ) = eltype(θ)(NaN)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -145,30 +145,30 @@ struct ParameterNode{I} <: AbstractNode
 end
 
 """
-    ParSource <: AbstractNode
+    DataSource <: AbstractNode
 
 Sentinel node used as the root of a parameter (data) array.  Indexing or
-accessing fields on a `ParSource` returns a [`ParIndexed`](@ref) node that
+accessing fields on a `DataSource` returns a [`DataIndexed`](@ref) node that
 encodes the access path as nested type parameters for zero-overhead data
 lookup.
 """
-struct ParSource <: AbstractNode end
+struct DataSource <: AbstractNode end
 
 """
-    ParIndexed{I, J} <: AbstractNode
+    DataIndexed{I, J} <: AbstractNode
 
 A node representing the lookup `inner.J` (or `inner[J]`) where `inner` is a
-`ParSource` or another `ParIndexed`.  The field/index `J` is encoded as a type
+`DataSource` or another `DataIndexed`.  The field/index `J` is encoded as a type
 parameter so that `getfield` / `getindex` can be resolved at compile time.
 
-Constructed implicitly via `getproperty` / `getindex` on a [`ParSource`](@ref).
+Constructed implicitly via `getproperty` / `getindex` on a [`DataSource`](@ref).
 """
-struct ParIndexed{I,J} <: AbstractNode
+struct DataIndexed{I,J} <: AbstractNode
     inner::I
 end
 
-@inline ParIndexed(inner::I, n) where {I} = ParIndexed{I,n}(inner)
-@inline ParIndexed(inner::I, s::Constant{n}) where {I,n} = ParIndexed{I,n}(inner)
+@inline DataIndexed(inner::I, n) where {I} = DataIndexed{I,n}(inner)
+@inline DataIndexed(inner::I, s::Constant{n}) where {I,n} = DataIndexed{I,n}(inner)
 """
     Node1{F, I} <: AbstractNode
 
@@ -208,13 +208,13 @@ struct SecondFixed{F}
     inner::F
 end
 
-@inline Base.getproperty(n::ParSource, s::Symbol) = ParIndexed(n, s)
-@inline Base.getindex(n::ParSource, i) = ParIndexed(n, i)
-@inline Base.indexed_iterate(n::P, idx, start = 1) where P <: Union{ParSource, ParIndexed} = (ParIndexed(n, idx), idx + 1)
+@inline Base.getproperty(n::DataSource, s::Symbol) = DataIndexed(n, s)
+@inline Base.getindex(n::DataSource, i) = DataIndexed(n, i)
+@inline Base.indexed_iterate(n::P, idx, start = 1) where P <: Union{DataSource, DataIndexed} = (DataIndexed(n, idx), idx + 1)
 
-@inline Base.getproperty(v::ParIndexed{I, n}, s::Symbol) where {I, n} = ParIndexed(v, s)
-@inline Base.getindex(v::ParIndexed{I, n}, i) where {I, n} = ParIndexed(v, i)
-@inline Base.indexed_iterate(v::ParIndexed{I, n}, idx, start = 1) where {I, n} = (ParIndexed(v, idx), idx + 1)
+@inline Base.getproperty(v::DataIndexed{I, n}, s::Symbol) where {I, n} = DataIndexed(v, s)
+@inline Base.getindex(v::DataIndexed{I, n}, i) where {I, n} = DataIndexed(v, i)
+@inline Base.indexed_iterate(v::DataIndexed{I, n}, idx, start = 1) where {I, n} = (DataIndexed(v, idx), idx + 1)
 
 
 @inline Base.getindex(n::VarSource, i) = Var(i)
@@ -235,11 +235,11 @@ struct Identity end
 @inline (v::ParameterNode{I})(::Any, x, θ) where {I} = @inbounds θ[v.i]
 @inline (v::ParameterNode{I})(::Identity, x, θ) where {I<:AbstractNode} = @inbounds θ[v.i]
 
-@inline (v::ParSource)(i, x, θ) = i
-@inline (v::ParIndexed{I,n})(i, x, θ) where {I,n} = @inbounds getfield(getfield(v, :inner)(i, x, θ), n)
+@inline (v::DataSource)(i, x, θ) = i
+@inline (v::DataIndexed{I,n})(i, x, θ) where {I,n} = @inbounds getfield(getfield(v, :inner)(i, x, θ), n)
 
-@inline (v::ParIndexed)(i::Identity, x, θ) = eltype(θ)(NaN) 
-@inline (v::ParSource)(i::Identity, x, θ) = eltype(θ)(NaN) 
+@inline (v::DataIndexed)(i::Identity, x, θ) = eltype(θ)(NaN)
+@inline (v::DataSource)(i::Identity, x, θ) = eltype(θ)(NaN)
 
 """
     AdjointNode1{F, T, I} <: AbstractAdjointNode

--- a/src/simdfunction.jl
+++ b/src/simdfunction.jl
@@ -39,7 +39,7 @@ Returns a `SIMDFunction` using the `gen`.
 - `o2`: offset for the second-order derivative evalution
 """
 @inline function SIMDFunction(T, gen::Base.Generator, o0 = 0, o1 = 0, o2 = 0)
-    _simdfunction(T, gen.f(ParSource()), o0, o1, o2)
+    _simdfunction(T, gen.f(DataSource()), o0, o1, o2)
 end
 
 @inline function _simdfunction(T, f::F, o0, o1, o2) where {F<:Real}
@@ -104,7 +104,7 @@ end
 _gr_val(::Type{<:AdjointNodeVar}) = Val(1)
 _gr_val(::Type{<:AdjointNull}) = Val(0)
 _gr_val(::Type{<:Real}) = Val(0)
-_gr_val(::Type{<:ParIndexed}) = Val(0)
+_gr_val(::Type{<:DataIndexed}) = Val(0)
 _gr_val(::Type{AdjointNode1{F,T,I}}) where {F,T,I} = _gr_val(I)
 _gr_val(::Type{AdjointNode2{F,T,I1,I2}}) where {F,T,I1,I2} =
     _add_vals(_gr_val(I1), _gr_val(I2))

--- a/test/JuMPTest/JuMPTest.jl
+++ b/test/JuMPTest/JuMPTest.jl
@@ -60,7 +60,7 @@ function fixed_variable_e2etest()
         typeof(*),
         ExaModels.Var{T1},
         T2,
-    } where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    } where {T1<:ExaModels.DataIndexed,T2<:ExaModels.DataIndexed}
 
     @test em.cons[3] isa ExaModels.Constraint
     @test em.cons[3].f.f isa ExaModels.Null{Nothing}
@@ -70,7 +70,7 @@ function fixed_variable_e2etest()
         typeof(*),
         T1,
         ExaModels.Node1{typeof(abs2),ExaModels.Var{T2}},
-    } where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    } where {T1<:ExaModels.DataIndexed,T2<:ExaModels.DataIndexed}
 
     jm = JuMP.Model()
 
@@ -91,14 +91,14 @@ function fixed_variable_e2etest()
         typeof(*),
         ExaModels.ParameterNode{T1},
         T2,
-    } where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    } where {T1<:ExaModels.DataIndexed,T2<:ExaModels.DataIndexed}
     @test em.cons[3] isa ExaModels.ConstraintAugmentation
     @test em.cons[3].f.f isa Pair
     @test typeof(em.cons[3].f.f.second) <: ExaModels.Node2{
         typeof(*),
         ExaModels.Var{T1},
         T2,
-    } where {T1<:ExaModels.ParIndexed,T2<:ExaModels.ParIndexed}
+    } where {T1<:ExaModels.DataIndexed,T2<:ExaModels.DataIndexed}
     @test em.cons[4] isa ExaModels.Constraint
     @test em.cons[4].f.f isa ExaModels.Null{Nothing}
 
@@ -121,7 +121,7 @@ function no_constraints_e2etest()
 
     @test em.objs[1].f.f isa ExaModels.Null
     @test typeof(em.objs[2].f.f) <:
-          ExaModels.Node1{typeof(sin),ExaModels.Var{T1}} where {T1<:ExaModels.ParIndexed}
+          ExaModels.Node1{typeof(sin),ExaModels.Var{T1}} where {T1<:ExaModels.DataIndexed}
 
     N=5
     jm = JuMP.Model()


### PR DESCRIPTION
This PR renames `ParSource` to `DataSource` and `ParIndexed` to `DataIndexed` to avoid naming conflicts with `Parameter`/`ParameterNode`.

## Changes

- Rename `ParSource` → `DataSource` and `ParIndexed` → `DataIndexed` in `src/graph.jl`
- Update all references in `src/gradient.jl`, `src/simdfunction.jl`, `src/ExaModels.jl`
- Update MOI extension (`ext/ExaModelsMOI.jl`) 
- Update type assertions in `test/JuMPTest/JuMPTest.jl`
- Apply Runic formatting fixes (spacing in type parameters and where clauses)
- Add `DataIndexed` constructor for `Constant` index parameter