### PR TITLE
New constraint augmentation syntax

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ if !(@isdefined _PAGES)
         "Mathematical Abstraction" => "simd.md",
         "Tutorial" => [
             "guide.md",
+            "patterns.md",
             "performance.md",
             "gpu.md",
             "parameters.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ if !(@isdefined _PAGES)
         "Tutorial" => [
             "guide.md",
             "patterns.md",
+            "constraint_augmentation.md",
             "performance.md",
             "gpu.md",
             "parameters.md",

--- a/docs/src/constraint_augmentation.md
+++ b/docs/src/constraint_augmentation.md
@@ -1,0 +1,176 @@
+# [Constraint Augmentation with `add_con!`](@id constraint-augmentation)
+
+!!! warning "Key Concept"
+    Constraint augmentation via `add_con!` is perhaps the **single most important
+    concept** that distinguishes ExaModels from other algebraic modeling tools like
+    JuMP.  Understanding when and why to use it is essential for writing efficient
+    ExaModels code --- especially on GPUs.
+
+## Background: Expression Patterns and Compilation
+
+ExaModels achieves its performance by compiling specialized derivative
+evaluation code for each unique **expression pattern** in your model.  Each call
+to `@add_obj` or `@add_con` introduces one pattern.  The derivative code for
+that pattern is then applied over all data points in the iterator via SIMD-style
+parallelism.
+
+This design has two important consequences:
+
+1. **Compilation cost scales with the number of unique patterns**, not the
+   number of constraints.  A model with 3 patterns over 1,000,000 data points
+   compiles almost as fast as the same 3 patterns over 100 data points.
+
+2. **GPU performance depends on few, large kernels.**  Each expression pattern
+   becomes a GPU kernel.  Many small kernels mean many kernel launches, which
+   is slow.  Fewer patterns with more data points per pattern is ideal.
+
+In JuMP, you can freely write arbitrarily complex per-constraint expressions
+because the AD system operates on a scalar expression graph.  In ExaModels,
+**keeping the number of expression patterns small** is critical for both
+compilation time and GPU scalability.
+
+## What `add_con!` Does
+
+`add_con!` **augments** an existing constraint by adding terms to it.  Instead
+of writing one monolithic expression per constraint, you build constraints
+incrementally --- each `add_con!` call contributes terms that share a single
+expression pattern:
+
+```julia
+c = ExaCore(concrete = Val(true))
+@add_var(c, x, n)
+
+# Create the base constraint (e.g., a balance equation)
+@add_con(c, base, rhs[i] for i in 1:n_buses)
+
+# Augment with contributions from different sources
+@add_con!(c, base, a.bus => flow[a.i] for a in arcs)
+@add_con!(c, base, g.bus => -gen[g.i] for g in generators)
+```
+
+### Syntax
+
+`add_con!` supports two equivalent calling conventions:
+
+**Three-argument form** --- the constraint and index-expression pair are separate arguments:
+
+```julia
+@add_con!(c, g, a.bus => p[a.i] for a in arc_data)
+# or at the function level:
+c, _ = add_con!(c, g, a.bus => p[a.i] for a in arc_data)
+```
+
+The syntax `a.bus => p[a.i]` means: "add the value `p[a.i]` to the
+constraint row identified by index `a.bus`."
+
+**Two-argument `+=` form** --- the constraint and index are embedded directly:
+
+```julia
+@add_con!(c, g[a.bus] += p[a.i] for a in arc_data)
+# or at the function level:
+c, _ = add_con!(c, g[a.bus] += p[a.i] for a in arc_data)
+```
+
+The `+=` form reads more naturally --- "add `p[a.i]` into `g[a.bus]`" ---
+and is fully equivalent.  Both forms compile to the same code.
+
+Multiple augmentations on the same base constraint are summed at evaluation time.
+
+## Example: Power Balance in Optimal Power Flow
+
+The canonical use case is power balance constraints in AC Optimal Power Flow.
+Each bus must balance power from loads, generators, and line flows:
+
+```math
+\sum_{\text{gen}} P_g - \sum_{\text{arc}} P_f - P_d - G_s \cdot V_m^2 = 0 \quad \forall \text{bus}
+```
+
+Without `add_con!`, you would need to construct a single expression that
+references all generators and arcs connected to each bus --- a complex,
+bus-specific expression that varies in structure per bus.  This would produce
+as many patterns as there are distinct bus topologies.
+
+With `add_con!`, the same model decomposes into simple, uniform patterns:
+
+```julia
+# Base: load and shunt (one pattern, iterated over buses)
+@add_con(c, p_balance, b.pd + b.gs * vm[b.i]^2 for b in bus_data)
+
+# Arc flows (one pattern, iterated over arcs)
+@add_con!(c, p_balance[a.bus] += p[a.i] for a in arc_data)
+
+# Generation (one pattern, iterated over generators)
+@add_con!(c, p_balance[g.bus] += -pg[g.i] for g in gen_data)
+```
+
+Three simple patterns instead of one complex per-bus pattern.  Each pattern
+compiles quickly and maps to a single efficient GPU kernel.
+
+## Example: Data-Driven Dynamics (Reducing Compilation Blowup)
+
+Consider a quantum optimal control problem with 20 state variables, where each
+state equation has 50+ terms involving products of controls and trigonometric
+functions.  A naive approach defines a separate dynamics function for each state:
+
+```julia
+# Naive: 20 different expression patterns (one per state equation)
+function dyn_1(x, u, v, t, n)
+    return -2.0 * x[11,t,n] +
+           1.414 * u[1,t] * u[2,t] * x[12,t,n] * cos(v[6]) + ...
+end
+
+function dyn_2(x, u, v, t, n)
+    # ... different structure
+end
+# ... up to dyn_20
+
+for i in 1:20
+    @add_con(c, x[i,j+1,k] - x[i,j,k] - dyns[i](x,u,v,j+1,k) * dt
+             for (j,k) in grid)
+end
+```
+
+This creates 20 distinct expression patterns.  Compilation time grows with each
+new pattern, and on GPUs, 20 separate kernels are launched per evaluation.
+As the number of states grows to hundreds or thousands, this approach becomes
+impractical.
+
+The solution is to **restructure the dynamics as data** and use `add_con!`:
+
+```julia
+# Build a single array encoding ALL terms across ALL state equations
+terms = [
+    (con = state_idx, coeff = coefficient, xi = x_index,
+     ui = u_index1, uj = u_index2, vi = v_index)
+    for (state_idx, coefficient, x_index, ...) in all_dynamics_terms
+]
+
+# One base constraint for all state equations
+@add_con(c, dynamics, x[i,j+1,k] - x[i,j,k] for (i,j,k) in state_grid)
+
+# One augmentation pattern for ALL terms across ALL equations
+@add_con!(c, dynamics[t.con] += t.coeff * x[t.xi] * u[t.ui] * u[t.uj] * cos(v[t.vi])
+    for t in terms
+)
+```
+
+Now there are only **2 expression patterns** regardless of how many state
+variables or terms exist.  The complexity is moved from compiled code into data
+arrays, which is exactly what GPUs excel at processing.
+
+!!! info "When to use `add_con!`"
+    Use `add_con!` whenever a constraint naturally decomposes into
+    contributions from **different data sources** (e.g., generators, arcs,
+    loads contributing to bus balance), or when you have **many structurally
+    similar terms** that can be parameterized by data.  The goal is always to
+    **minimize the number of unique expression patterns** in your model.
+
+## Summary
+
+| Approach | Patterns | Compilation | GPU Performance |
+|---|---|---|---|
+| One complex expression per constraint | Many (grows with model complexity) | Slow | Poor (many kernel launches) |
+| `add_con` + `add_con!` augmentation | Few (fixed by problem structure) | Fast | Excellent (few large kernels) |
+
+See the [Optimal Power Flow example](@ref opf) for a complete working
+example using `@add_con!`.

--- a/docs/src/patterns.md
+++ b/docs/src/patterns.md
@@ -1,13 +1,14 @@
-# [Modeling Patterns](@id patterns)
+# [Macro Behavior: Returning `core` from Functions](@id macro-behavior)
 
-This page covers two important modeling patterns that are unique to
-ExaModels and deserve special attention.
+The `@add_var`, `@add_par`, `@add_obj`, `@add_con`, `@add_con!`, and `@add_expr`
+macros all share an important behavior that users should understand,
+especially when writing model-building functions.
 
-## Macro Behavior: Returning `core` from Functions
+## How the Macros Work
 
 In ExaModels v0.10, `ExaCore` (created with `concrete = Val(true)`) is an
-**immutable** struct. Every model-building call — `add_var`, `add_obj`,
-`add_con`, etc. — returns a **new** core rather than modifying the old one:
+**immutable** struct. Every model-building call --- `add_var`, `add_obj`,
+`add_con`, etc. --- returns a **new** core rather than modifying the old one:
 
 ```julia
 c = ExaCore(concrete = Val(true))
@@ -16,7 +17,7 @@ c, _ = add_obj(c, x[i]^2 for i in 1:10)  # c is rebound again
 ```
 
 The `@add_var`-family macros are thin wrappers that do the same thing
-behind the scenes — they **rebind** the core variable in the calling scope:
+behind the scenes --- they **rebind** the core variable in the calling scope:
 
 ```julia
 c = ExaCore(concrete = Val(true))
@@ -28,7 +29,7 @@ This rebinding is the key behavior to keep in mind: after every macro call,
 `c` points to a new `ExaCore` that contains all previously accumulated
 information **plus** the newly added component.
 
-### The Pitfall: Functions That Forget to Return `core`
+## The Pitfall: Functions That Forget to Return `core`
 
 This works fine at the top level. But when you build a model inside a
 **function**, the rebinding of `c` only affects the function's local scope.
@@ -36,13 +37,13 @@ If you forget to return the final `core`, the caller never sees the
 accumulated model information:
 
 ```julia
-# WRONG — the caller gets nothing useful
+# WRONG --- the caller gets nothing useful
 function build_model_wrong()
     c = ExaCore(concrete = Val(true))
     @add_var(c, x, 10)
     @add_obj(c, x[i]^2 for i in 1:10)
     @add_con(c, x[i] + x[i+1] for i in 1:9)
-    # c is local — it is lost when the function returns!
+    # c is local --- it is lost when the function returns!
 end
 ```
 
@@ -50,7 +51,7 @@ The fix is straightforward: **return `core`** (or an `ExaModel` built from it)
 at the end of the function:
 
 ```julia
-# CORRECT — return the ExaModel (or core) to the caller
+# CORRECT --- return the ExaModel (or core) to the caller
 function build_model()
     c = ExaCore(concrete = Val(true))
     @add_var(c, x, 10)
@@ -65,7 +66,7 @@ This applies to **all** `@add_*` macros: `@add_var`, `@add_par`, `@add_obj`,
 so the last `c` in your function is the only one that holds the complete model
 definition. Either return it directly or pass it to `ExaModel(c)`.
 
-### Returning `core` for Further Composition
+## Returning `core` for Further Composition
 
 When you want to build a model in stages across multiple functions, return
 the core itself so the caller can continue adding components:
@@ -89,157 +90,3 @@ end
 !!! tip
     A good rule of thumb: any function that calls `@add_*` macros should
     **return `c`** as its last expression.
-
----
-
-## Constraint Augmentation with `add_con!`
-
-The `@add_con!` macro (and its functional form `add_con!`) is perhaps the most
-distinctive feature of ExaModels compared to other modeling tools like JuMP.
-Understanding when and why to use it is key to writing efficient ExaModels code.
-
-### Background: Expression Patterns and Compilation
-
-ExaModels achieves its performance by compiling specialized derivative
-evaluation code for each unique **expression pattern** in your model. Each call
-to `@add_obj` or `@add_con` introduces one pattern. The derivative code for
-that pattern is then applied over all data points in the iterator via SIMD-style
-parallelism.
-
-This design has two important consequences:
-
-1. **Compilation cost scales with the number of unique patterns**, not the
-   number of constraints. A model with 3 patterns over 1,000,000 data points
-   compiles almost as fast as the same 3 patterns over 100 data points.
-
-2. **GPU performance depends on few, large kernels.** Each expression pattern
-   becomes a GPU kernel. Many small kernels mean many kernel launches, which
-   is slow. Fewer patterns with more data points per pattern is ideal.
-
-In JuMP, you can freely write arbitrarily complex per-constraint expressions
-because the AD system operates on a scalar expression graph. In ExaModels,
-keeping the number of expression patterns small is critical for both compilation
-time and GPU scalability.
-
-### What `add_con!` Does
-
-`@add_con!` **augments** an existing constraint by adding terms to it. Instead
-of writing one monolithic expression per constraint, you build constraints
-incrementally — each `@add_con!` call contributes terms that share a single
-expression pattern:
-
-```julia
-c = ExaCore(concrete = Val(true))
-@add_var(c, x, n)
-
-# Create the base constraint (e.g., a balance equation)
-@add_con(c, base, rhs[i] for i in 1:n_buses)
-
-# Augment with contributions from different sources
-@add_con!(c, base, a.bus => flow[a.i] for a in arcs)
-@add_con!(c, base, g.bus => -gen[g.i] for g in generators)
-```
-
-The syntax `a.bus => flow[a.i]` means: "add the value `flow[a.i]` to the
-constraint row identified by index `a.bus`." Multiple augmentations on the same
-base constraint are summed at evaluation time.
-
-### Example: Power Balance in Optimal Power Flow
-
-The canonical use case is power balance constraints in AC Optimal Power Flow.
-Each bus must balance power from loads, generators, and line flows:
-
-```math
-\sum_{\text{gen}} P_g - \sum_{\text{arc}} P_f - P_d - G_s \cdot V_m^2 = 0 \quad \forall \text{bus}
-```
-
-Without `add_con!`, you would need to construct a single expression that
-references all generators and arcs connected to each bus — a complex,
-bus-specific expression that varies in structure per bus. This would produce
-as many patterns as there are distinct bus topologies.
-
-With `add_con!`, the same model decomposes into simple, uniform patterns:
-
-```julia
-# Base: load and shunt (one pattern, iterated over buses)
-@add_con(c, p_balance, b.pd + b.gs * vm[b.i]^2 for b in bus_data)
-
-# Arc flows (one pattern, iterated over arcs)
-@add_con!(c, p_balance, a.bus => p[a.i] for a in arc_data)
-
-# Generation (one pattern, iterated over generators)
-@add_con!(c, p_balance, g.bus => -pg[g.i] for g in gen_data)
-```
-
-Three simple patterns instead of one complex per-bus pattern. Each pattern
-compiles quickly and maps to a single efficient GPU kernel.
-
-### Example: Data-Driven Dynamics (Reducing Compilation Blowup)
-
-Consider a quantum optimal control problem with 20 state variables, where each
-state equation has 50+ terms involving products of controls and trigonometric
-functions. A naive approach defines a separate dynamics function for each state:
-
-```julia
-# Naive: 20 different expression patterns (one per state equation)
-function dyn_1(x, u, v, t, n)
-    return -2.0 * x[11,t,n] +
-           1.414 * u[1,t] * u[2,t] * x[12,t,n] * cos(v[6]) + ...
-end
-
-function dyn_2(x, u, v, t, n)
-    # ... different structure
-end
-# ... up to dyn_20
-
-for i in 1:20
-    @add_con(c, x[i,j+1,k] - x[i,j,k] - dyns[i](x,u,v,j+1,k) * dt
-             for (j,k) in grid)
-end
-```
-
-This creates 20 distinct expression patterns. Compilation time grows with each
-new pattern, and on GPUs, 20 separate kernels are launched per evaluation.
-As the number of states grows to hundreds or thousands, this approach becomes
-impractical.
-
-The solution is to **restructure the dynamics as data** and use `add_con!`:
-
-```julia
-# Build a single array encoding ALL terms across ALL state equations
-terms = [
-    (con = state_idx, coeff = coefficient, xi = x_index,
-     ui = u_index1, uj = u_index2, vi = v_index)
-    for (state_idx, coefficient, x_index, ...) in all_dynamics_terms
-]
-
-# One base constraint for all state equations
-@add_con(c, dynamics, x[i,j+1,k] - x[i,j,k] for (i,j,k) in state_grid)
-
-# One augmentation pattern for ALL terms across ALL equations
-@add_con!(c, dynamics,
-    t.con => t.coeff * x[t.xi] * u[t.ui] * u[t.uj] * cos(v[t.vi])
-    for t in terms
-)
-```
-
-Now there are only **2 expression patterns** regardless of how many state
-variables or terms exist. The complexity is moved from compiled code into data
-arrays, which is exactly what GPUs excel at processing.
-
-!!! info "When to use `add_con!`"
-    Use `add_con!` whenever a constraint naturally decomposes into
-    contributions from **different data sources** (e.g., generators, arcs,
-    loads contributing to bus balance), or when you have **many structurally
-    similar terms** that can be parameterized by data. The goal is always to
-    **minimize the number of unique expression patterns** in your model.
-
-### Summary
-
-| Approach | Patterns | Compilation | GPU Performance |
-|---|---|---|---|
-| One complex expression per constraint | Many (grows with model complexity) | Slow | Poor (many kernel launches) |
-| `add_con` + `add_con!` augmentation | Few (fixed by problem structure) | Fast | Excellent (few large kernels) |
-
-See the [Optimal Power Flow example](@ref opf) for a complete working
-example using `@add_con!`.

--- a/docs/src/patterns.md
+++ b/docs/src/patterns.md
@@ -1,0 +1,245 @@
+# [Modeling Patterns](@id patterns)
+
+This page covers two important modeling patterns that are unique to
+ExaModels and deserve special attention.
+
+## Macro Behavior: Returning `core` from Functions
+
+In ExaModels v0.10, `ExaCore` (created with `concrete = Val(true)`) is an
+**immutable** struct. Every model-building call — `add_var`, `add_obj`,
+`add_con`, etc. — returns a **new** core rather than modifying the old one:
+
+```julia
+c = ExaCore(concrete = Val(true))
+c, x = add_var(c, 10)       # c is rebound to a new ExaCore
+c, _ = add_obj(c, x[i]^2 for i in 1:10)  # c is rebound again
+```
+
+The `@add_var`-family macros are thin wrappers that do the same thing
+behind the scenes — they **rebind** the core variable in the calling scope:
+
+```julia
+c = ExaCore(concrete = Val(true))
+@add_var(c, x, 10)          # expands to: c, x = add_var(c, 10)
+@add_obj(c, x[i]^2 for i in 1:10)  # expands to: c, _ = add_obj(c, ...)
+```
+
+This rebinding is the key behavior to keep in mind: after every macro call,
+`c` points to a new `ExaCore` that contains all previously accumulated
+information **plus** the newly added component.
+
+### The Pitfall: Functions That Forget to Return `core`
+
+This works fine at the top level. But when you build a model inside a
+**function**, the rebinding of `c` only affects the function's local scope.
+If you forget to return the final `core`, the caller never sees the
+accumulated model information:
+
+```julia
+# WRONG — the caller gets nothing useful
+function build_model_wrong()
+    c = ExaCore(concrete = Val(true))
+    @add_var(c, x, 10)
+    @add_obj(c, x[i]^2 for i in 1:10)
+    @add_con(c, x[i] + x[i+1] for i in 1:9)
+    # c is local — it is lost when the function returns!
+end
+```
+
+The fix is straightforward: **return `core`** (or an `ExaModel` built from it)
+at the end of the function:
+
+```julia
+# CORRECT — return the ExaModel (or core) to the caller
+function build_model()
+    c = ExaCore(concrete = Val(true))
+    @add_var(c, x, 10)
+    @add_obj(c, x[i]^2 for i in 1:10)
+    @add_con(c, x[i] + x[i+1] for i in 1:9)
+    return ExaModel(c)   # <-- pass the final core to ExaModel
+end
+```
+
+This applies to **all** `@add_*` macros: `@add_var`, `@add_par`, `@add_obj`,
+`@add_con`, `@add_con!`, and `@add_expr`. Each one rebinds the core variable,
+so the last `c` in your function is the only one that holds the complete model
+definition. Either return it directly or pass it to `ExaModel(c)`.
+
+### Returning `core` for Further Composition
+
+When you want to build a model in stages across multiple functions, return
+the core itself so the caller can continue adding components:
+
+```julia
+function add_dynamics!(c, x, u, data)
+    @add_con(c, x[i+1] - x[i] - u[i] * data[i].dt for i in 1:length(data))
+    return c   # <-- return updated core for further building
+end
+
+function full_model()
+    c = ExaCore(concrete = Val(true))
+    @add_var(c, x, 11)
+    @add_var(c, u, 10)
+    c = add_dynamics!(c, x, u, data)   # rebind c with the returned core
+    @add_obj(c, x[i]^2 for i in 1:11)
+    return ExaModel(c)
+end
+```
+
+!!! tip
+    A good rule of thumb: any function that calls `@add_*` macros should
+    **return `c`** as its last expression.
+
+---
+
+## Constraint Augmentation with `add_con!`
+
+The `@add_con!` macro (and its functional form `add_con!`) is perhaps the most
+distinctive feature of ExaModels compared to other modeling tools like JuMP.
+Understanding when and why to use it is key to writing efficient ExaModels code.
+
+### Background: Expression Patterns and Compilation
+
+ExaModels achieves its performance by compiling specialized derivative
+evaluation code for each unique **expression pattern** in your model. Each call
+to `@add_obj` or `@add_con` introduces one pattern. The derivative code for
+that pattern is then applied over all data points in the iterator via SIMD-style
+parallelism.
+
+This design has two important consequences:
+
+1. **Compilation cost scales with the number of unique patterns**, not the
+   number of constraints. A model with 3 patterns over 1,000,000 data points
+   compiles almost as fast as the same 3 patterns over 100 data points.
+
+2. **GPU performance depends on few, large kernels.** Each expression pattern
+   becomes a GPU kernel. Many small kernels mean many kernel launches, which
+   is slow. Fewer patterns with more data points per pattern is ideal.
+
+In JuMP, you can freely write arbitrarily complex per-constraint expressions
+because the AD system operates on a scalar expression graph. In ExaModels,
+keeping the number of expression patterns small is critical for both compilation
+time and GPU scalability.
+
+### What `add_con!` Does
+
+`@add_con!` **augments** an existing constraint by adding terms to it. Instead
+of writing one monolithic expression per constraint, you build constraints
+incrementally — each `@add_con!` call contributes terms that share a single
+expression pattern:
+
+```julia
+c = ExaCore(concrete = Val(true))
+@add_var(c, x, n)
+
+# Create the base constraint (e.g., a balance equation)
+@add_con(c, base, rhs[i] for i in 1:n_buses)
+
+# Augment with contributions from different sources
+@add_con!(c, base, a.bus => flow[a.i] for a in arcs)
+@add_con!(c, base, g.bus => -gen[g.i] for g in generators)
+```
+
+The syntax `a.bus => flow[a.i]` means: "add the value `flow[a.i]` to the
+constraint row identified by index `a.bus`." Multiple augmentations on the same
+base constraint are summed at evaluation time.
+
+### Example: Power Balance in Optimal Power Flow
+
+The canonical use case is power balance constraints in AC Optimal Power Flow.
+Each bus must balance power from loads, generators, and line flows:
+
+```math
+\sum_{\text{gen}} P_g - \sum_{\text{arc}} P_f - P_d - G_s \cdot V_m^2 = 0 \quad \forall \text{bus}
+```
+
+Without `add_con!`, you would need to construct a single expression that
+references all generators and arcs connected to each bus — a complex,
+bus-specific expression that varies in structure per bus. This would produce
+as many patterns as there are distinct bus topologies.
+
+With `add_con!`, the same model decomposes into simple, uniform patterns:
+
+```julia
+# Base: load and shunt (one pattern, iterated over buses)
+@add_con(c, p_balance, b.pd + b.gs * vm[b.i]^2 for b in bus_data)
+
+# Arc flows (one pattern, iterated over arcs)
+@add_con!(c, p_balance, a.bus => p[a.i] for a in arc_data)
+
+# Generation (one pattern, iterated over generators)
+@add_con!(c, p_balance, g.bus => -pg[g.i] for g in gen_data)
+```
+
+Three simple patterns instead of one complex per-bus pattern. Each pattern
+compiles quickly and maps to a single efficient GPU kernel.
+
+### Example: Data-Driven Dynamics (Reducing Compilation Blowup)
+
+Consider a quantum optimal control problem with 20 state variables, where each
+state equation has 50+ terms involving products of controls and trigonometric
+functions. A naive approach defines a separate dynamics function for each state:
+
+```julia
+# Naive: 20 different expression patterns (one per state equation)
+function dyn_1(x, u, v, t, n)
+    return -2.0 * x[11,t,n] +
+           1.414 * u[1,t] * u[2,t] * x[12,t,n] * cos(v[6]) + ...
+end
+
+function dyn_2(x, u, v, t, n)
+    # ... different structure
+end
+# ... up to dyn_20
+
+for i in 1:20
+    @add_con(c, x[i,j+1,k] - x[i,j,k] - dyns[i](x,u,v,j+1,k) * dt
+             for (j,k) in grid)
+end
+```
+
+This creates 20 distinct expression patterns. Compilation time grows with each
+new pattern, and on GPUs, 20 separate kernels are launched per evaluation.
+As the number of states grows to hundreds or thousands, this approach becomes
+impractical.
+
+The solution is to **restructure the dynamics as data** and use `add_con!`:
+
+```julia
+# Build a single array encoding ALL terms across ALL state equations
+terms = [
+    (con = state_idx, coeff = coefficient, xi = x_index,
+     ui = u_index1, uj = u_index2, vi = v_index)
+    for (state_idx, coefficient, x_index, ...) in all_dynamics_terms
+]
+
+# One base constraint for all state equations
+@add_con(c, dynamics, x[i,j+1,k] - x[i,j,k] for (i,j,k) in state_grid)
+
+# One augmentation pattern for ALL terms across ALL equations
+@add_con!(c, dynamics,
+    t.con => t.coeff * x[t.xi] * u[t.ui] * u[t.uj] * cos(v[t.vi])
+    for t in terms
+)
+```
+
+Now there are only **2 expression patterns** regardless of how many state
+variables or terms exist. The complexity is moved from compiled code into data
+arrays, which is exactly what GPUs excel at processing.
+
+!!! info "When to use `add_con!`"
+    Use `add_con!` whenever a constraint naturally decomposes into
+    contributions from **different data sources** (e.g., generators, arcs,
+    loads contributing to bus balance), or when you have **many structurally
+    similar terms** that can be parameterized by data. The goal is always to
+    **minimize the number of unique expression patterns** in your model.
+
+### Summary
+
+| Approach | Patterns | Compilation | GPU Performance |
+|---|---|---|---|
+| One complex expression per constraint | Many (grows with model complexity) | Slow | Poor (many kernel launches) |
+| `add_con` + `add_con!` augmentation | Few (fixed by problem structure) | Fast | Excellent (few large kernels) |
+
+See the [Optimal Power Flow example](@ref opf) for a complete working
+example using `@add_con!`.

--- a/ext/ExaModelsKernelAbstractions.jl
+++ b/ext/ExaModelsKernelAbstractions.jl
@@ -488,7 +488,7 @@ function ExaModels.sjacobian!(
     adj,
 ) where {B<:KernelAbstractions.Backend}
     if !isempty(f.itr)
-        kerj(backend)(y1, y2, f.f, f.itr, x, θ, adj; ndrange = length(f.itr))
+        kerj(backend)(y1, y2, f.f, f.itr, x, θ, adj, ExaModels._constraint_dims(f); ndrange = length(f.itr))
     end
 end
 
@@ -518,7 +518,7 @@ function ExaModels.shessian!(
     adj2,
 ) where {B<:KernelAbstractions.Backend,V<:AbstractVector}
     if !isempty(f.itr)
-        kerh2(backend)(y1, y2, f.f, f.itr, x, θ, adj, adj2; ndrange = length(f.itr))
+        kerh2(backend)(y1, y2, f.f, f.itr, x, θ, adj, adj2, ExaModels._constraint_dims(f); ndrange = length(f.itr))
     end
 end
 
@@ -553,7 +553,8 @@ end
     @Const(x),
     @Const(θ),
     @Const(adjs1),
-    @Const(adj2)
+    @Const(adj2),
+    @Const(dims)
 )
     I = @index(Global)
     @inbounds ExaModels.hrpass0(
@@ -563,17 +564,17 @@ end
         y2,
         ExaModels.offset2(f, I),
         0,
-        adjs1[ExaModels.offset0(f, itr, I)],
+        adjs1[ExaModels.offset0(f, itr, I, dims)],
         adj2,
     )
 end
 
-@kernel function kerj(y1, y2, @Const(f), @Const(itr), @Const(x), @Const(θ), @Const(adj))
+@kernel function kerj(y1, y2, @Const(f), @Const(itr), @Const(x), @Const(θ), @Const(adj), @Const(dims))
     I = @index(Global)
     @inbounds ExaModels.jrpass(
         f(itr[I], ExaModels.AdjointNodeSource(x), θ),
         f.comp1,
-        ExaModels.offset0(f, itr, I),
+        ExaModels.offset0(f, itr, I, dims),
         y1,
         y2,
         ExaModels.offset1(f, I),

--- a/ext/ExaModelsKernelAbstractions.jl
+++ b/ext/ExaModelsKernelAbstractions.jl
@@ -122,11 +122,11 @@ _conaug_structure!(T, backend, ::Tuple{}, sparsity) = nothing
 function _conaug_structure!(T, backend, (con, cons...), sparsity)
     _conaug_structure!(T, backend, cons, sparsity)
     con isa ExaModels.ConstraintAugmentation && !isempty(con.itr) &&
-        kers(backend)(sparsity, con.f, con.itr, con.oa; ndrange = length(con.itr))
+        kers(backend)(sparsity, con.f, con.itr, con.oa, con.dims; ndrange = length(con.itr))
 end
-@kernel function kers(sparsity, @Const(f), @Const(itr), @Const(oa))
+@kernel function kers(sparsity, @Const(f), @Const(itr), @Const(oa), @Const(dims))
     I = @index(Global)
-    @inbounds sparsity[oa+I] = (ExaModels.offset0(f, itr, I), oa + I)
+    @inbounds sparsity[oa+I] = (ExaModels.offset0(f, itr, I, dims), oa + I)
 end
 
 
@@ -242,11 +242,10 @@ function ExaModels.grad!(
 ) where {T,VT,E<:KAExtension,V<:AbstractVector}
     gradbuffer = m.ext.gradbuffer
 
+    fill!(y, zero(eltype(y)))
     if !isempty(gradbuffer)
         fill!(gradbuffer, zero(eltype(gradbuffer)))
         _grad!(m.ext.backend, m.ext.gradbuffer, m.objs, x, m.θ)
-
-        fill!(y, zero(eltype(y)))
         compress_to_dense(m.ext.backend)(
             y,
             gradbuffer,
@@ -254,7 +253,7 @@ function ExaModels.grad!(
             m.ext.gsparsity;
             ndrange = length(m.ext.gptr) - 1,
         )
-        end
+    end
 
     return y
 end

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -172,32 +172,42 @@ struct ConstraintSlot{C, I}
     idx::I
 end
 
-const _AUGMENT_CONSTRAINT_REF = Ref{Any}(nothing)
+"""
+    ConAugPair{C, P}
 
-# For 1D constraints: single index, adjust for range start.
-# When start == 1 (the common case), pass idx through unchanged to
-# preserve the exact type expected by SIMDFunction/offset0.
+Carries a constraint reference (`con`) alongside its `Pair(idx, expr)` during
+the probe phase of `add_con!(core, g[i] += expr for ...)`.  The `replace_T`
+method unwraps to the inner `Pair`, so `SIMDFunction` stores a plain `Pair`
+and all existing `offset0` dispatches remain unchanged.
+"""
+struct ConAugPair{C, P}
+    con::C
+    pair::P
+end
+
+# Unwrap to the inner Pair when SIMDFunction does type-conversion on literals.
+# After this, SIMDFunction.f is a plain Pair — no new offset0 dispatches needed.
+@inline replace_T(t, cap::ConAugPair) = replace_T(t, cap.pair)
+
+# For 1D constraints: single index, adjusted for the range start (always
+# computes i - (s-1) for a uniform return type regardless of start value).
 Base.getindex(c::Constraint, i) = begin
-    _AUGMENT_CONSTRAINT_REF[] = c
     s = _start(c.size[1])
-    ConstraintSlot(c, s == 1 ? i : i - (s - 1))
+    ConstraintSlot(c, i - (s - 1))
 end
 # For multi-dim constraints: tuple indices, adjust each for its range start.
 # Uses recursive tuple construction (not ntuple) for GPU compatibility.
-Base.getindex(c::Constraint, idx::Vararg{Any,N}) where {N} = begin
-    _AUGMENT_CONSTRAINT_REF[] = c
+Base.getindex(c::Constraint, idx::Vararg{Any,N}) where {N} =
     ConstraintSlot(c, _adjust_tuple(idx, c.size))
-end
-Base.getindex(c::ConstraintAugmentation, idx...) = begin
-    _AUGMENT_CONSTRAINT_REF[] = c
-    ConstraintSlot(c, length(idx) == 1 ? idx[1] : idx)
-end
-Base.:+(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, expr)
-Base.:+(expr::AbstractNode, slot::ConstraintSlot) = Pair(slot.idx, expr)
-Base.:+(slot::ConstraintSlot, expr::Real) = Pair(slot.idx, Null(expr))
-Base.:+(expr::Real, slot::ConstraintSlot) = Pair(slot.idx, Null(expr))
-Base.:-(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, -expr)
-Base.:-(slot::ConstraintSlot, expr::Real) = Pair(slot.idx, Null(-expr))
+Base.getindex(c::ConstraintAugmentation, idx...) =
+    ConstraintSlot(c, idx)
+
+Base.:+(slot::ConstraintSlot, expr::AbstractNode) = ConAugPair(slot.con, Pair(slot.idx, expr))
+Base.:+(expr::AbstractNode, slot::ConstraintSlot) = ConAugPair(slot.con, Pair(slot.idx, expr))
+Base.:+(slot::ConstraintSlot, expr::Real) = ConAugPair(slot.con, Pair(slot.idx, Null(expr)))
+Base.:+(expr::Real, slot::ConstraintSlot) = ConAugPair(slot.con, Pair(slot.idx, Null(expr)))
+Base.:-(slot::ConstraintSlot, expr::AbstractNode) = ConAugPair(slot.con, Pair(slot.idx, -expr))
+Base.:-(slot::ConstraintSlot, expr::Real) = ConAugPair(slot.con, Pair(slot.idx, Null(-expr)))
 Base.setindex!(::Constraint, val, idx...) = val
 Base.setindex!(::ConstraintAugmentation, val, idx...) = val
 
@@ -210,9 +220,9 @@ Base.setindex!(::ConstraintAugmentation, val, idx...) = val
 end
 
 # Adjust a single index for the range start.
-# When start == 1, pass through unchanged to preserve the original type.
+# Always computes idx - (start-1) for a uniform return type (type-stable).
 # Literal integers are wrapped in Constant so they remain callable by `coord`.
-@inline _con_adjust(idx, start) = start == 1 ? idx : idx - (start - 1)
+@inline _con_adjust(idx, start) = idx - (start - 1)
 @inline _con_adjust(idx::Integer, start) = Constant(idx - start + 1)
 
 abstract type AbstractExaCore{T,VT,B,S} end
@@ -1100,21 +1110,17 @@ c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
 @inline function add_con!(c::ExaCore{T}, gen::Base.Generator) where T
     gen = _adapt_gen(gen)
 
-    # Probe the generator to extract the target constraint.
-    # getindex on Constraint/ConstraintAugmentation records the constraint
-    # in _AUGMENT_CONSTRAINT_REF as a side effect.
-    _AUGMENT_CONSTRAINT_REF[] = nothing
-    gen.f(DataSource())
-    con = _AUGMENT_CONSTRAINT_REF[]
-    _AUGMENT_CONSTRAINT_REF[] = nothing
-
-    con === nothing && error(
+    # Probe the generator: the result is a ConAugPair which carries the target
+    # constraint alongside the index/expression pair.
+    probe = gen.f(DataSource())
+    probe isa ConAugPair || error(
         "add_con! two-argument form requires `constraint[idx] += expr` syntax " *
         "in the generator body"
     )
+    con = probe.con
 
-    # The generator already yields Pair(idx, expr) thanks to the
-    # ConstraintSlot + AbstractNode → Pair overload, so delegate directly.
+    # The generator yields ConAugPair values; replace_T unwraps them to plain
+    # Pairs before SIMDFunction stores them, so offset0 dispatch is unchanged.
     return add_con!(c, con, gen)
 end
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -173,9 +173,17 @@ end
 
 const _AUGMENT_CONSTRAINT_REF = Ref{Any}(nothing)
 
-Base.getindex(c::Constraint, idx...) = begin
+# For 1D constraints: single index, adjust for range start.
+Base.getindex(c::Constraint, i) = begin
     _AUGMENT_CONSTRAINT_REF[] = c
-    ConstraintSlot(c, length(idx) == 1 ? idx[1] : idx)
+    ConstraintSlot(c, i - (_con_start1(c.itr) - 1))
+end
+# For multi-dim constraints: tuple indices, adjust each for its range start.
+# Integer results are wrapped in Constant so they remain callable by `coord`.
+Base.getindex(c::Constraint, idx::Vararg{Any,N}) where {N} = begin
+    _AUGMENT_CONSTRAINT_REF[] = c
+    starts = _con_starts(c.itr)
+    ConstraintSlot(c, ntuple(k -> _con_adjust(idx[k], starts[k]), Val(N)))
 end
 Base.getindex(c::ConstraintAugmentation, idx...) = begin
     _AUGMENT_CONSTRAINT_REF[] = c
@@ -185,6 +193,19 @@ Base.:+(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, expr)
 Base.:+(expr::AbstractNode, slot::ConstraintSlot) = Pair(slot.idx, expr)
 Base.setindex!(::Constraint, val, idx...) = val
 Base.setindex!(::ConstraintAugmentation, val, idx...) = val
+
+# Adjust a single index for the range start.
+# Symbolic nodes: arithmetic produces a Node2 (callable by coord).
+# Literal integers: wrap in Constant so coord can call it.
+@inline _con_adjust(idx, start) = idx - (start - 1)
+@inline _con_adjust(idx::Integer, start) = Constant(idx - start + 1)
+
+# Extract range starts from constraint iterators.
+@inline _con_start1(itr::AbstractRange) = first(itr)
+@inline _con_start1(itr::AbstractArray{<:Tuple}) = itr[1][1]
+@inline _con_start1(itr) = 1
+@inline _con_starts(itr::AbstractArray{<:Tuple}) = itr[1]
+@inline _con_starts(itr) = ntuple(_ -> 1, ndims(itr))
 
 abstract type AbstractExaCore{T,VT,B,S} end
 
@@ -1518,7 +1539,8 @@ true
 function multipliers(result::SolverCore.AbstractExecutionStats, y::Constraint)
     o = y.offset
     len = length(y.itr)
-    return view(result.multipliers, (o+1):(o+len))
+    s = Base.size(y.itr)
+    return reshape(view(result.multipliers, (o+1):(o+len)), s...)
 end
 
 _adapt_gen(gen) = Base.Generator(gen.f, collect(gen.iter))

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1100,7 +1100,7 @@ c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
     # getindex on Constraint/ConstraintAugmentation records the constraint
     # in _AUGMENT_CONSTRAINT_REF as a side effect.
     _AUGMENT_CONSTRAINT_REF[] = nothing
-    gen.f(ParSource())
+    gen.f(DataSource())
     con = _AUGMENT_CONSTRAINT_REF[]
     _AUGMENT_CONSTRAINT_REF[] = nothing
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -174,16 +174,19 @@ end
 const _AUGMENT_CONSTRAINT_REF = Ref{Any}(nothing)
 
 # For 1D constraints: single index, adjust for range start.
+# When start == 1 (the common case), pass idx through unchanged to
+# preserve the exact type expected by SIMDFunction/offset0.
 Base.getindex(c::Constraint, i) = begin
     _AUGMENT_CONSTRAINT_REF[] = c
-    ConstraintSlot(c, i - (_con_start1(c.itr) - 1))
+    s = _con_start1(c.itr)
+    ConstraintSlot(c, s == 1 ? i : i - (s - 1))
 end
 # For multi-dim constraints: tuple indices, adjust each for its range start.
-# Integer results are wrapped in Constant so they remain callable by `coord`.
+# Uses recursive tuple construction (not ntuple) for GPU compatibility.
 Base.getindex(c::Constraint, idx::Vararg{Any,N}) where {N} = begin
     _AUGMENT_CONSTRAINT_REF[] = c
     starts = _con_starts(c.itr)
-    ConstraintSlot(c, ntuple(k -> _con_adjust(idx[k], starts[k]), Val(N)))
+    ConstraintSlot(c, _adjust_tuple(idx, starts))
 end
 Base.getindex(c::ConstraintAugmentation, idx...) = begin
     _AUGMENT_CONSTRAINT_REF[] = c
@@ -194,10 +197,15 @@ Base.:+(expr::AbstractNode, slot::ConstraintSlot) = Pair(slot.idx, expr)
 Base.setindex!(::Constraint, val, idx...) = val
 Base.setindex!(::ConstraintAugmentation, val, idx...) = val
 
+# Recursive tuple adjustment — avoids ntuple/getindex(::Tuple,::Int) for GPU compat.
+@inline _adjust_tuple(idx::Tuple{}, starts::Tuple{}) = ()
+@inline _adjust_tuple(idx::Tuple, starts::Tuple) =
+    (_con_adjust(first(idx), first(starts)), _adjust_tuple(Base.tail(idx), Base.tail(starts))...)
+
 # Adjust a single index for the range start.
-# Symbolic nodes: arithmetic produces a Node2 (callable by coord).
-# Literal integers: wrap in Constant so coord can call it.
-@inline _con_adjust(idx, start) = idx - (start - 1)
+# When start == 1, pass through unchanged to preserve the original type.
+# Literal integers are wrapped in Constant so they remain callable by `coord`.
+@inline _con_adjust(idx, start) = start == 1 ? idx : idx - (start - 1)
 @inline _con_adjust(idx::Integer, start) = Constant(idx - start + 1)
 
 # Extract range starts from constraint iterators.

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -920,11 +920,16 @@ is intended for code that builds expression trees programmatically.
 end
 
 """
-    add_con(core, n; start = 0, lcon = 0, ucon = 0, name = nothing)
+    add_con(core, dims...; start = 0, lcon = 0, ucon = 0, name = nothing)
 
-Adds `n` empty constraints to `core` and returns `(core, Constraint)`.
-No expression is attached initially — use [`add_con!`](@ref) / [`@add_con!`](@ref)
-to accumulate terms into the rows afterwards.
+Adds empty constraints with dimensions specified by `dims` to `core` and returns
+`(core, Constraint)`.  No expression is attached initially — use
+[`add_con!`](@ref) / [`@add_con!`](@ref) to accumulate terms into the rows
+afterwards.
+
+`dims` can be a single integer (`add_con(c, 9)`), multiple integers
+(`add_con(c, 3, 4)` for a 3×4 grid), or `AbstractUnitRange` values
+(`add_con(c, 1:3, 2:5)`) — matching the convention used by [`add_var`](@ref).
 
 When `name` is given as `Val(:name)`, the constraint is also accessible as
 `core.name` or `model.name`.
@@ -952,7 +957,7 @@ Constraint
 """
 @inline function add_con(
     c::C,
-    n;
+    ns...;
     name = nothing,
     start = zero(T),
     lcon = zero(T),
@@ -962,39 +967,6 @@ Constraint
 
     f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
 
-    _add_con(c, f, 1:n, start, lcon, ucon, name; kwargs...)
-end
-
-# Explicit 2D overload for empty multi-dimensional constraints
-function add_con(
-    c::C,
-    n1::N1,
-    n2::N2;
-    name = nothing,
-    start = zero(T),
-    lcon = zero(T),
-    ucon = zero(T),
-    kwargs...
-) where {T, C<:ExaCore{T}, N1<:Union{Integer,AbstractUnitRange}, N2<:Union{Integer,AbstractUnitRange}}
-    ns = (n1, n2)
-    f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
-    _add_con(c, f, ConstraintDims(ns), start, lcon, ucon, name; kwargs...)
-end
-
-# Explicit 3D overload for empty multi-dimensional constraints
-function add_con(
-    c::C,
-    n1::N1,
-    n2::N2,
-    n3::N3;
-    name = nothing,
-    start = zero(T),
-    lcon = zero(T),
-    ucon = zero(T),
-    kwargs...
-) where {T, C<:ExaCore{T}, N1<:Union{Integer,AbstractUnitRange}, N2<:Union{Integer,AbstractUnitRange}, N3<:Union{Integer,AbstractUnitRange}}
-    ns = (n1, n2, n3)
-    f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
     _add_con(c, f, ConstraintDims(ns), start, lcon, ucon, name; kwargs...)
 end
 
@@ -1107,7 +1079,7 @@ c, g = add_con(c, 9; lcon = -1.0, ucon = 1.0)
 c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
 ```
 """
-function add_con!(c::ExaCore{T}, gen::Base.Generator) where T
+@inline function add_con!(c::ExaCore{T}, gen::Base.Generator) where T
     gen = _adapt_gen(gen)
 
     # Probe the generator to extract the target constraint.

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -107,10 +107,11 @@ A block of constraints added to an [`ExaCore`](@ref) via [`add_con`](@ref) /
 Row `k` of this block maps to global constraint index `offset + k`. Dual
 solution values can be retrieved with [`multipliers`](@ref).
 """
-struct Constraint{F,I,O} <: AbstractConstraint
+struct Constraint{F,I,O,S} <: AbstractConstraint
     f::F
     itr::I
     offset::O
+    size::S
 end
 Base.show(io::IO, v::Constraint) = print(
     io,
@@ -178,15 +179,14 @@ const _AUGMENT_CONSTRAINT_REF = Ref{Any}(nothing)
 # preserve the exact type expected by SIMDFunction/offset0.
 Base.getindex(c::Constraint, i) = begin
     _AUGMENT_CONSTRAINT_REF[] = c
-    s = _con_start1(c.itr)
+    s = _start(c.size[1])
     ConstraintSlot(c, s == 1 ? i : i - (s - 1))
 end
 # For multi-dim constraints: tuple indices, adjust each for its range start.
 # Uses recursive tuple construction (not ntuple) for GPU compatibility.
 Base.getindex(c::Constraint, idx::Vararg{Any,N}) where {N} = begin
     _AUGMENT_CONSTRAINT_REF[] = c
-    starts = _con_starts(c.itr)
-    ConstraintSlot(c, _adjust_tuple(idx, starts))
+    ConstraintSlot(c, _adjust_tuple(idx, c.size))
 end
 Base.getindex(c::ConstraintAugmentation, idx...) = begin
     _AUGMENT_CONSTRAINT_REF[] = c
@@ -198,22 +198,18 @@ Base.setindex!(::Constraint, val, idx...) = val
 Base.setindex!(::ConstraintAugmentation, val, idx...) = val
 
 # Recursive tuple adjustment — avoids ntuple/getindex(::Tuple,::Int) for GPU compat.
-@inline _adjust_tuple(idx::Tuple{}, starts::Tuple{}) = ()
-@inline _adjust_tuple(idx::Tuple, starts::Tuple) =
-    (_con_adjust(first(idx), first(starts)), _adjust_tuple(Base.tail(idx), Base.tail(starts))...)
+# `dims` is the constraint's size tuple (ints or ranges); _start extracts the start.
+@inline _adjust_tuple(idx::Tuple{}, dims::Tuple{}) = ()
+@inline _adjust_tuple(idx::Tuple, dims::Tuple) = begin
+    s = _start(first(dims))
+    (_con_adjust(first(idx), s), _adjust_tuple(Base.tail(idx), Base.tail(dims))...)
+end
 
 # Adjust a single index for the range start.
 # When start == 1, pass through unchanged to preserve the original type.
 # Literal integers are wrapped in Constant so they remain callable by `coord`.
 @inline _con_adjust(idx, start) = start == 1 ? idx : idx - (start - 1)
 @inline _con_adjust(idx::Integer, start) = Constant(idx - start + 1)
-
-# Extract range starts from constraint iterators.
-@inline _con_start1(itr::AbstractRange) = first(itr)
-@inline _con_start1(itr::AbstractArray{<:Tuple}) = itr[1][1]
-@inline _con_start1(itr) = 1
-@inline _con_starts(itr::AbstractArray{<:Tuple}) = itr[1]
-@inline _con_starts(itr) = ntuple(_ -> 1, ndims(itr))
 
 abstract type AbstractExaCore{T,VT,B,S} end
 
@@ -860,11 +856,12 @@ Constraint
     kwargs...
 ) where {T,C<:ExaCore{T}}
 
+    dims = _infer_subexpr_dims(gen.iter)
     gen = _adapt_gen(gen)
     f = SIMDFunction(T, gen, c.ncon, c.nnzj, c.nnzh)
     pars = gen.iter
 
-    _add_con(c, f, pars, start, lcon, ucon, name; kwargs...)
+    _add_con(c, f, pars, dims, start, lcon, ucon, name; kwargs...)
 end
 
 """
@@ -926,8 +923,9 @@ is intended for code that builds expression trees programmatically.
 ) where {T,C<:ExaCore{T},N<:AbstractNode}
 
     f = _simdfunction(T,expr, c.ncon, c.nnzj, c.nnzh)
+    dims = _infer_subexpr_dims(pars)
 
-    _add_con(c, f, pars, start, lcon, ucon, name; kwargs...)
+    _add_con(c, f, pars, dims, start, lcon, ucon, name; kwargs...)
 end
 
 """
@@ -979,7 +977,7 @@ Constraint
     f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
     pars = _empty_con_itr(ns)
 
-    _add_con(c, f, pars, start, lcon, ucon, name; kwargs...)
+    _add_con(c, f, pars, ns, start, lcon, ucon, name; kwargs...)
 end
 
 # Build an iterator for empty constraints: 1:n for 1D, collected ProductIterator for multi-dim.
@@ -987,7 +985,7 @@ _empty_con_itr(ns::Tuple{Any}) = 1:_length(ns[1])
 _empty_con_itr(ns::Tuple) = collect(Iterators.product(map(n -> 1:_length(n), ns)...))
 
 
-function _add_con(c::C, f, pars, start, lcon, ucon, name = nothing; kwargs...) where {C<:ExaCore}
+function _add_con(c::C, f, pars, dims, start, lcon, ucon, name = nothing; kwargs...) where {C<:ExaCore}
     nitr = length(pars)
     o = c.ncon
     ncon = c.ncon + nitr
@@ -999,7 +997,7 @@ function _add_con(c::C, f, pars, start, lcon, ucon, name = nothing; kwargs...) w
     ucon = append!(c.backend, c.ucon, ucon, nitr)
     append_con_tags(c.tags, c.backend, nitr; kwargs...)
 
-    con = Constraint(f, convert_array(pars, c.backend), o)
+    con = Constraint(f, convert_array(pars, c.backend), o, dims)
 
     (ExaCore(c; ncon=ncon, nnzj=nnzj, nnzh=nnzh, y0=y0, lcon=lcon, ucon=ucon, cons=(con, c.cons...), refs = add_refs(c.refs, name, con)), con)
 end
@@ -1117,7 +1115,7 @@ c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
 end
 
 # Extract the dimensions of the original constraint's iterator
-_constraint_dims(c::Constraint) = Base.size(c.itr)
+_constraint_dims(c::Constraint) = Tuple(_length(n) for n in c.size)
 _constraint_dims(c::ConstraintAugmentation) = c.dims
 
 function _add_con!(c, f, pars, dims)
@@ -1546,8 +1544,8 @@ true
 """
 function multipliers(result::SolverCore.AbstractExecutionStats, y::Constraint)
     o = y.offset
-    len = length(y.itr)
-    s = Base.size(y.itr)
+    len = total(y.size)
+    s = size(y.size)
     return reshape(view(result.multipliers, (o+1):(o+len)), s...)
 end
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -196,6 +196,8 @@ Base.:+(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, expr)
 Base.:+(expr::AbstractNode, slot::ConstraintSlot) = Pair(slot.idx, expr)
 Base.:+(slot::ConstraintSlot, expr::Real) = Pair(slot.idx, Null(expr))
 Base.:+(expr::Real, slot::ConstraintSlot) = Pair(slot.idx, Null(expr))
+Base.:-(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, -expr)
+Base.:-(slot::ConstraintSlot, expr::Real) = Pair(slot.idx, Null(-expr))
 Base.setindex!(::Constraint, val, idx...) = val
 Base.setindex!(::ConstraintAugmentation, val, idx...) = val
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1116,8 +1116,11 @@ c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
     return add_con!(c, con, gen)
 end
 
-# Extract the dimensions of the original constraint's iterator
-_constraint_dims(c::Constraint) = Tuple(_length(n) for n in c.size)
+# Extract the dimensions of the original constraint's iterator.
+# Use Base.size(c.itr) rather than transforming c.size: the itr is always shaped
+# correctly (1D range or N-dim array), and Base.size returns concrete Int lengths
+# which is required for type-stable dispatch in juliac AOT compilation.
+_constraint_dims(c::Constraint) = Base.size(c.itr)
 _constraint_dims(c::ConstraintAugmentation) = c.dims
 
 function _add_con!(c, f, pars, dims)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -155,24 +155,6 @@ Constraint Augmentation
 )
 
 """
-    ConstraintDims{T}
-
-A lightweight iterator-like wrapper around dimension specifications for
-multi-dimensional empty constraints created via `add_con(core, dims...)`.
-Stores the dimension tuple and supports `Base.size`, `length`, and linear
-indexing.
-"""
-struct ConstraintDims{T}
-    ns::T
-end
-Base.size(d::ConstraintDims) = Tuple(_length(n) for n in d.ns)
-Base.length(d::ConstraintDims) = prod(_length(n) for n in d.ns)
-Base.getindex(d::ConstraintDims, i) = i
-Base.firstindex(::ConstraintDims) = 1
-Base.lastindex(d::ConstraintDims) = length(d)
-convert_array(d::ConstraintDims, _) = d
-
-"""
     ConstraintSlot{C, I}
 
 A lightweight handle returned by `getindex` on a [`Constraint`](@ref) or
@@ -966,9 +948,14 @@ Constraint
 ) where {T,C<:ExaCore{T}}
 
     f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
+    pars = _empty_con_itr(ns)
 
-    _add_con(c, f, ConstraintDims(ns), start, lcon, ucon, name; kwargs...)
+    _add_con(c, f, pars, start, lcon, ucon, name; kwargs...)
 end
+
+# Build an iterator for empty constraints: 1:n for 1D, collected ProductIterator for multi-dim.
+_empty_con_itr(ns::Tuple{Any}) = 1:_length(ns[1])
+_empty_con_itr(ns::Tuple) = collect(Iterators.product(map(n -> 1:_length(n), ns)...))
 
 
 function _add_con(c::C, f, pars, start, lcon, ucon, name = nothing; kwargs...) where {C<:ExaCore}

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1365,6 +1365,7 @@ _con_hprod!(cons::Tuple{}, x, θ, y, v, Hv, obj_weight) = nothing
 end
 
 @inbounds @inline offset0(a, i) = offset0(a.f, i)
+@inbounds @inline offset0(a::Constraint, i) = offset0(a.f, a.itr, i, _constraint_dims(a))
 @inbounds @inline offset1(a, i) = offset1(a.f, i)
 @inbounds @inline offset2(a, i) = offset2(a.f, i)
 @inbounds @inline offset0(f, itr, i) = offset0(f, i)
@@ -1372,20 +1373,14 @@ end
 @inbounds @inline offset1(f::F, i) where {F<:SIMDFunction} = f.o1 + f.o1step * (i - 1)
 @inbounds @inline offset2(f::F, i) where {F<:SIMDFunction} = f.o2 + f.o2step * (i - 1)
 @inbounds @inline offset0(a::C, i) where {C<:ConstraintAugmentation} = offset0(a.f, a.itr, i, a.dims)
-@inbounds @inline offset0(f::F, itr, i) where {P<:Pair,F<:SIMDFunction{P}} =
-    f.o0 + f.f.first(itr[i], nothing, nothing)
-@inbounds @inline offset0(f::F, itr, i) where {I<:Integer,P<:Pair{I},F<:SIMDFunction{P}} =
-    f.o0 + f.f.first
-@inbounds @inline offset0(f::F, itr, i) where {T<:Tuple,P<:Pair{T},F<:SIMDFunction{P}} =
-    f.o0 + idxx(coord(itr, i, f.f.first), Base.size(itr))
-# 4-arg variant used by ConstraintAugmentation to pass original constraint dims
-@inbounds @inline offset0(f, itr, i, dims) = offset0(f, i)
 @inbounds @inline offset0(f::F, itr, i, dims) where {P<:Pair,F<:SIMDFunction{P}} =
     f.o0 + f.f.first(itr[i], nothing, nothing)
 @inbounds @inline offset0(f::F, itr, i, dims) where {I<:Integer,P<:Pair{I},F<:SIMDFunction{P}} =
     f.o0 + f.f.first
 @inbounds @inline offset0(f::F, itr, i, dims) where {T<:Tuple,P<:Pair{T},F<:SIMDFunction{P}} =
     f.o0 + idxx(coord(itr, i, f.f.first), dims)
+# Non-Pair fallback: plain linear offset (used by Objective, non-Pair Constraint)
+@inbounds @inline offset0(f::F, itr, i, dims) where {F<:SIMDFunction} = f.o0 + i
 
 @inline idx(itr, I) = @inbounds itr[I]
 @inline idx(itr::Base.Iterators.ProductIterator{V}, I) where {V} =

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1370,18 +1370,23 @@ end
 @inbounds @inline offset0(a::Constraint, i) = offset0(a.f, a.itr, i, _constraint_dims(a))
 @inbounds @inline offset1(a, i) = offset1(a.f, i)
 @inbounds @inline offset2(a, i) = offset2(a.f, i)
+# 3-arg form: used by KA extension kernels which receive (f::SIMDFunction, itr, i)
 @inbounds @inline offset0(f, itr, i) = offset0(f, i)
+@inbounds @inline offset0(f::F, itr, i) where {P<:Pair,F<:SIMDFunction{P}} =
+    f.o0 + f.f.first(itr[i], nothing, nothing)
+@inbounds @inline offset0(f::F, itr, i) where {I<:Integer,P<:Pair{I},F<:SIMDFunction{P}} =
+    f.o0 + f.f.first
 @inbounds @inline offset0(f::F, i) where {F<:SIMDFunction} = f.o0 + i
 @inbounds @inline offset1(f::F, i) where {F<:SIMDFunction} = f.o1 + f.o1step * (i - 1)
 @inbounds @inline offset2(f::F, i) where {F<:SIMDFunction} = f.o2 + f.o2step * (i - 1)
 @inbounds @inline offset0(a::C, i) where {C<:ConstraintAugmentation} = offset0(a.f, a.itr, i, a.dims)
+# 4-arg form: used when dims are available (from Constraint.size or ConstraintAugmentation.dims)
 @inbounds @inline offset0(f::F, itr, i, dims) where {P<:Pair,F<:SIMDFunction{P}} =
     f.o0 + f.f.first(itr[i], nothing, nothing)
 @inbounds @inline offset0(f::F, itr, i, dims) where {I<:Integer,P<:Pair{I},F<:SIMDFunction{P}} =
     f.o0 + f.f.first
 @inbounds @inline offset0(f::F, itr, i, dims) where {T<:Tuple,P<:Pair{T},F<:SIMDFunction{P}} =
     f.o0 + idxx(coord(itr, i, f.f.first), dims)
-# Non-Pair fallback: plain linear offset (used by Objective, non-Pair Constraint)
 @inbounds @inline offset0(f::F, itr, i, dims) where {F<:SIMDFunction} = f.o0 + i
 
 @inline idx(itr, I) = @inbounds itr[I]

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -154,6 +154,56 @@ Constraint Augmentation
 """,
 )
 
+"""
+    ConstraintDims{T}
+
+A lightweight iterator-like wrapper around dimension specifications for
+multi-dimensional empty constraints created via `add_con(core, dims...)`.
+Stores the dimension tuple and supports `Base.size`, `length`, and linear
+indexing.
+"""
+struct ConstraintDims{T}
+    ns::T
+end
+Base.size(d::ConstraintDims) = Tuple(_length(n) for n in d.ns)
+Base.length(d::ConstraintDims) = prod(_length(n) for n in d.ns)
+Base.getindex(d::ConstraintDims, i) = i
+Base.firstindex(::ConstraintDims) = 1
+Base.lastindex(d::ConstraintDims) = length(d)
+convert_array(d::ConstraintDims, _) = d
+
+"""
+    ConstraintSlot{C, I}
+
+A lightweight handle returned by `getindex` on a [`Constraint`](@ref) or
+[`ConstraintAugmentation`](@ref).  When added to an expression node via `+`,
+it produces a `Pair(idx, expr)` suitable for constraint augmentation.
+
+This enables the `g[idx] += expr for ...` syntactic sugar:
+```julia
+c, _ = add_con!(c, g[i] += sin(x[i]) for i in 1:N)
+```
+"""
+struct ConstraintSlot{C, I}
+    con::C
+    idx::I
+end
+
+const _AUGMENT_CONSTRAINT_REF = Ref{Any}(nothing)
+
+Base.getindex(c::Constraint, idx...) = begin
+    _AUGMENT_CONSTRAINT_REF[] = c
+    ConstraintSlot(c, length(idx) == 1 ? idx[1] : idx)
+end
+Base.getindex(c::ConstraintAugmentation, idx...) = begin
+    _AUGMENT_CONSTRAINT_REF[] = c
+    ConstraintSlot(c, length(idx) == 1 ? idx[1] : idx)
+end
+Base.:+(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, expr)
+Base.:+(expr::AbstractNode, slot::ConstraintSlot) = Pair(slot.idx, expr)
+Base.setindex!(::Constraint, val, idx...) = val
+Base.setindex!(::ConstraintAugmentation, val, idx...) = val
+
 abstract type AbstractExaCore{T,VT,B,S} end
 
 """
@@ -915,6 +965,39 @@ Constraint
     _add_con(c, f, 1:n, start, lcon, ucon, name; kwargs...)
 end
 
+# Explicit 2D overload for empty multi-dimensional constraints
+function add_con(
+    c::C,
+    n1::N1,
+    n2::N2;
+    name = nothing,
+    start = zero(T),
+    lcon = zero(T),
+    ucon = zero(T),
+    kwargs...
+) where {T, C<:ExaCore{T}, N1<:Union{Integer,AbstractUnitRange}, N2<:Union{Integer,AbstractUnitRange}}
+    ns = (n1, n2)
+    f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
+    _add_con(c, f, ConstraintDims(ns), start, lcon, ucon, name; kwargs...)
+end
+
+# Explicit 3D overload for empty multi-dimensional constraints
+function add_con(
+    c::C,
+    n1::N1,
+    n2::N2,
+    n3::N3;
+    name = nothing,
+    start = zero(T),
+    lcon = zero(T),
+    ucon = zero(T),
+    kwargs...
+) where {T, C<:ExaCore{T}, N1<:Union{Integer,AbstractUnitRange}, N2<:Union{Integer,AbstractUnitRange}, N3<:Union{Integer,AbstractUnitRange}}
+    ns = (n1, n2, n3)
+    f = _simdfunction(T, Null(nothing), c.ncon, c.nnzj, c.nnzh)
+    _add_con(c, f, ConstraintDims(ns), start, lcon, ucon, name; kwargs...)
+end
+
 
 function _add_con(c::C, f, pars, start, lcon, ucon, name = nothing; kwargs...) where {C<:ExaCore}
     nitr = length(pars)
@@ -1005,6 +1088,44 @@ add_con!(c, bus, gen.bus => -pg[gen.i] for gen in data.gen)            # subtrac
     pars = gen.iter
 
     _add_con!(c, f, pars, _constraint_dims(c1))
+end
+
+"""
+    add_con!(core::ExaCore, gen::Base.Generator)
+
+Two-argument form of [`add_con!`](@ref) supporting the `constraint[idx] += expr` sugar.
+The generator must use the pattern `g[idx] += expr for ... in itr`, where `g` is an
+existing [`Constraint`](@ref) or [`ConstraintAugmentation`](@ref).
+
+Equivalent to `add_con!(core, g, idx => expr for ... in itr)`.
+
+## Example
+```julia
+c = ExaCore(concrete = Val(true))
+c, x = add_var(c, 10)
+c, g = add_con(c, 9; lcon = -1.0, ucon = 1.0)
+c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
+```
+"""
+function add_con!(c::ExaCore{T}, gen::Base.Generator) where T
+    gen = _adapt_gen(gen)
+
+    # Probe the generator to extract the target constraint.
+    # getindex on Constraint/ConstraintAugmentation records the constraint
+    # in _AUGMENT_CONSTRAINT_REF as a side effect.
+    _AUGMENT_CONSTRAINT_REF[] = nothing
+    gen.f(ParSource())
+    con = _AUGMENT_CONSTRAINT_REF[]
+    _AUGMENT_CONSTRAINT_REF[] = nothing
+
+    con === nothing && error(
+        "add_con! two-argument form requires `constraint[idx] += expr` syntax " *
+        "in the generator body"
+    )
+
+    # The generator already yields Pair(idx, expr) thanks to the
+    # ConstraintSlot + AbstractNode → Pair overload, so delegate directly.
+    return add_con!(c, con, gen)
 end
 
 # Extract the dimensions of the original constraint's iterator
@@ -1670,13 +1791,20 @@ end
 
 """
     @add_con!(core, c1, generator; kwargs...)
+    @add_con!(core, c1[idx] += expr for ...; kwargs...)
 
 Macro interface for [`add_con!`](@ref). Updates `core` in the calling scope and returns the
-new `ConstraintAugmentation`. Equivalent to `c, aug = add_con!(c, c1, generator)`.
+new `ConstraintAugmentation`.
 
-The generator must yield `idx => expr` pairs, where `idx` is an index into `c1` and `expr`
-is the scalar term to accumulate into that constraint row.  See [`add_con!`](@ref) for full
-semantics and usage notes.
+Two calling conventions are supported:
+
+- **Three-argument** (`@add_con!(core, c1, idx => expr for ...)`): the constraint `c1` is
+  passed explicitly and the generator yields `idx => expr` pairs.
+- **Two-argument** (`@add_con!(core, c1[idx] += expr for ...)`): the constraint and index
+  are embedded in the generator via `+=` syntax.  This form delegates to the function-level
+  [`add_con!(core, gen)`](@ref), which extracts the target constraint automatically.
+
+See [`add_con!`](@ref) for full semantics and usage notes.
 
 ## Example
 ```julia
@@ -1684,18 +1812,36 @@ c = ExaCore(concrete = Val(true))
 @add_var(c, x, 10)
 @add_con(c, g, x[i] + x[i+1] for i in 1:9; lcon = -1, ucon = 1)
 
-## Append sin(x[i+1]) to rows 4–6 of g:
+## Three-argument form:
 aug = @add_con!(c, g, i => sin(x[i+1]) for i in 4:6)
 
-## Power-flow pattern — multiple augmentations on the same base constraint:
-## @add_con!(c, bus_balance, arc.bus => p[arc.i]   for arc in data.arc)
-## @add_con!(c, bus_balance, gen.bus => -pg[gen.i] for gen in data.gen)
+## Two-argument form (equivalent):
+aug = @add_con!(c, g[i] += sin(x[i+1]) for i in 4:6)
 ```
 """
 macro add_con!(exs...)
-    isempty(exs) && error("@add_con! requires core, existing constraint, and generator arguments")
+    isempty(exs) && error("@add_con! requires core and generator arguments")
     parts, kwargs = _split_macro_args(exs)
     core  = parts[1]
+
+    if length(parts) == 2
+        # Two-argument form: @add_con!(core, g[idx] += expr for ...)
+        # Delegate to function-level add_con!(core, gen) which extracts
+        # the constraint automatically via the ConstraintSlot mechanism.
+        gen_expr = _auto_const_gen(parts[2])
+        con = gensym(:con)
+        return quote
+            local $con
+            $(esc(core)), $con = add_con!(
+                $(esc(core)),
+                $(esc(gen_expr));
+                $(map(esc, kwargs.args)...),
+            )
+            $con
+        end
+    end
+
+    # Three-argument form: @add_con!(core, c1, idx => expr for ...)
     c1    = parts[2]
     args  = [_auto_const_gen(a) for a in parts[3:end]]
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -194,6 +194,8 @@ Base.getindex(c::ConstraintAugmentation, idx...) = begin
 end
 Base.:+(slot::ConstraintSlot, expr::AbstractNode) = Pair(slot.idx, expr)
 Base.:+(expr::AbstractNode, slot::ConstraintSlot) = Pair(slot.idx, expr)
+Base.:+(slot::ConstraintSlot, expr::Real) = Pair(slot.idx, Null(expr))
+Base.:+(expr::Real, slot::ConstraintSlot) = Pair(slot.idx, Null(expr))
 Base.setindex!(::Constraint, val, idx...) = val
 Base.setindex!(::ConstraintAugmentation, val, idx...) = val
 

--- a/test/NLPTest/NLPTest.jl
+++ b/test/NLPTest/NLPTest.jl
@@ -43,6 +43,7 @@ include("parameter_test.jl")
 include("subexpr_test.jl")
 include("trivialmax.jl")
 include("feature_test.jl")
+include("conaug_test.jl")
 
 function test_nlp(m1, m2; full = false, tol = sol_tolerance(eltype(m1.meta.x0), eltype(m2.meta.x0)))
     @testset "NLP meta tests" begin
@@ -210,6 +211,10 @@ function runtests()
 
                 @testset "Feature Test" begin
                     test_features(backend)
+                end
+
+                @testset "Constraint Augmentation" begin
+                    test_conaug(backend)
                 end
             end
         end

--- a/test/NLPTest/conaug_test.jl
+++ b/test/NLPTest/conaug_test.jl
@@ -45,6 +45,29 @@ function test_conaug_1d(backend)
         g_vals = Array(NLPModels.cons(m, x0))
         @test all(≈(2.0), g_vals)
     end
+
+    @testset "add_con! with -= syntax (1D)" begin
+        N = 9
+        # g[i] -= expr should be equivalent to g[i] += (-expr)
+        c1 = ExaCore(; backend, concrete = Val(true))
+        c1, x1 = add_var(c1, N + 1)
+        c1, g1 = add_con(c1, N; lcon = -1.0, ucon = 1.0)
+        c1, _ = add_con!(c1, g1[i] -= x1[i] + x1[i+1] for i = 1:N)
+
+        # Reference: same result via +=(-expr)
+        c2 = ExaCore(; backend, concrete = Val(true))
+        c2, x2 = add_var(c2, N + 1)
+        c2, g2 = add_con(c2, N; lcon = -1.0, ucon = 1.0)
+        c2, _ = add_con!(c2, g2[i] += -(x2[i] + x2[i+1]) for i = 1:N)
+
+        m1 = ExaModel(c1)
+        m2 = ExaModel(c2)
+        @test m1.meta.nnzj == m2.meta.nnzj
+        @test m1.meta.nnzh == m2.meta.nnzh
+        x0 = ExaModels.convert_array(rand(N + 1), backend)
+        @test NLPModels.cons(m1, x0) ≈ NLPModels.cons(m2, x0)
+        @test NLPModels.grad(m1, x0) ≈ NLPModels.grad(m2, x0)
+    end
 end
 
 function test_conaug_2d(backend)

--- a/test/NLPTest/conaug_test.jl
+++ b/test/NLPTest/conaug_test.jl
@@ -42,7 +42,7 @@ function test_conaug_1d(backend)
 
         m = ExaModel(c)
         x0 = ExaModels.convert_array(ones(N + 1), backend)
-        g_vals = NLPModels.cons(m, x0)
+        g_vals = Array(NLPModels.cons(m, x0))
         @test all(≈(2.0), g_vals)
     end
 end

--- a/test/NLPTest/conaug_test.jl
+++ b/test/NLPTest/conaug_test.jl
@@ -68,10 +68,10 @@ function test_conaug_2d(backend)
         c, x = add_var(c, N, M)
         c, g = add_con(c, r1, r2; lcon = -Inf, ucon = 0.0)
         @test Base.size(g.itr) == (length(r1), length(r2))
-        @test g.itr.ns == (r1, r2)
 
-        itr = [(i, j) for i in r1, j in r2 if i < N][:]
-        c, _ = add_con!(c, g[i, j] += x[i, j-1] - x[i+1, j-1] for (i, j) in itr)
+        # Augmentation uses 1-based indices into the constraint block
+        itr = [(i, j) for i = 1:length(r1)-1, j = 1:length(r2)][:]
+        c, _ = add_con!(c, g[i, j] += x[i, j] - x[i+1, j] for (i, j) in itr)
         m = ExaModel(c)
         @test m.meta.ncon == length(r1) * length(r2)
         @test m.meta.nnzj == length(itr) * 2

--- a/test/NLPTest/conaug_test.jl
+++ b/test/NLPTest/conaug_test.jl
@@ -59,33 +59,64 @@ function test_conaug_2d(backend)
         m = ExaModel(c)
         @test m.meta.ncon == N * M
         @test m.meta.nnzj == length(itr) * 2
+
+        # Verify actual constraint values: g[i,j] = x[i,j] - x[i+1,j] for i<N, else 0
+        x0 = ExaModels.convert_array(collect(Float64, 1:N*M), backend)
+        g_vals = Array(NLPModels.cons(m, x0))
+        # constraints stored in column-major order: linear index (i,j) → (j-1)*N + i
+        for j = 1:M, i = 1:N
+            k = (j - 1) * N + i
+            expected = i < N ? Float64((j - 1) * N + i) - Float64((j - 1) * N + i + 1) : 0.0
+            @test g_vals[k] ≈ expected
+        end
     end
 
-    @testset "add_con(core, dims...) — range-based 2D dims" begin
+    @testset "add_con(core, dims...) — range-based 2D dims (non-unit start)" begin
         N, M = 3, 4
-        r1, r2 = 1:N, 2:M+1
+        r1, r2 = 1:N, 2:M+1   # r2 starts at 2: j ∈ 2..5 in range space, 1..4 block-local
+        # x has M+1 columns so x[i,j] is valid for j up to M+1
         c = ExaCore(; backend, concrete = Val(true))
-        c, x = add_var(c, N, M)
+        c, x = add_var(c, N, M + 1)
         c, g = add_con(c, r1, r2; lcon = -Inf, ucon = 0.0)
         @test Base.size(g.itr) == (length(r1), length(r2))
+        @test length(g.itr) == N * M
 
-        # Augmentation uses 1-based indices into the constraint block
-        itr = [(i, j) for i = 1:length(r1)-1, j = 1:length(r2)][:]
+        # For range-based constraints, augmentation indices must use range values:
+        # i ∈ r1 = 1:N, j ∈ r2 = 2:M+1.  _con_adjust then maps j → j-(start-1).
+        itr = [(i, j) for i = first(r1):last(r1)-1, j = r2][:]
         c, _ = add_con!(c, g[i, j] += x[i, j] - x[i+1, j] for (i, j) in itr)
         m = ExaModel(c)
-        @test m.meta.ncon == length(r1) * length(r2)
+        @test m.meta.ncon == N * M
         @test m.meta.nnzj == length(itr) * 2
+
+        # x0[k] = k, so x[i,j] = (j-1)*N+i → x[i,j]-x[i+1,j] = -1 for all valid (i,j)
+        x0 = ExaModels.convert_array(collect(Float64, 1:N*(M+1)), backend)
+        g_vals = Array(NLPModels.cons(m, x0))
+        for j_col = 1:M, i = 1:N
+            k = (j_col - 1) * N + i
+            expected = i < N ? -1.0 : 0.0
+            @test g_vals[k] ≈ expected
+        end
     end
 
-    @testset "add_con(core, dims...) — 3D integer dims" begin
+    @testset "add_con(core, dims...) — 3D integer dims with value check" begin
         N, M, K = 2, 3, 4
         c = ExaCore(; backend, concrete = Val(true))
-        c, x = add_var(c, N * M * K)  # need at least one variable
+        c, x = add_var(c, N * M * K)
         c, g = add_con(c, N, M, K; lcon = 0.0, ucon = 0.0)
         @test Base.size(g.itr) == (N, M, K)
         @test length(g.itr) == N * M * K
+
+        # Augment with a non-trivial expression: g[i,j,k] += x[linidx(i,j,k)] * 2 for all (i,j,k)
+        itr3 = [(i, j, k) for i = 1:N, j = 1:M, k = 1:K][:]
+        c, _ = add_con!(c, g[i, j, kk] += x[(kk-1)*N*M + (j-1)*N + i] * 2 for (i, j, kk) in itr3)
         m = ExaModel(c)
         @test m.meta.ncon == N * M * K
+        @test m.meta.nnzj == length(itr3)
+
+        x0 = ExaModels.convert_array(ones(N * M * K), backend)
+        g_vals = Array(NLPModels.cons(m, x0))
+        @test all(≈(2.0), g_vals)
     end
 
     @testset "range-based 2D matches integer 2D (same result)" begin
@@ -111,6 +142,52 @@ function test_conaug_2d(backend)
 
         x0 = ExaModels.convert_array(rand(N * M), backend)
         @test NLPModels.cons(m1, x0) ≈ NLPModels.cons(m2, x0)
+
+        # Also verify against CPU reference (only when backend isn't already CPU)
+        c_ref = ExaCore(; concrete = Val(true))
+        c_ref, x_ref = add_var(c_ref, N, M)
+        c_ref, g_ref = add_con(c_ref, N, M; lcon = -1.0, ucon = 1.0)
+        c_ref, _ = add_con!(c_ref, g_ref[i, j] += x_ref[i, j] - x_ref[i+1, j] for (i, j) in itr)
+        m_ref = ExaModel(c_ref)
+        x0_cpu = collect(Float64, Array(x0))
+        @test Array(NLPModels.cons(m1, x0)) ≈ NLPModels.cons(m_ref, x0_cpu)
+    end
+
+    @testset "multiple augmentations on same 2D constraint" begin
+        N, M = 4, 5
+        # Two separate augmentations: forward and backward differences
+        itr_fwd = [(i, j) for i = 1:N-1, j = 1:M][:]
+        itr_bwd = [(i, j) for i = 2:N, j = 1:M][:]
+
+        c = ExaCore(; backend, concrete = Val(true))
+        c, x = add_var(c, N, M)
+        c, g = add_con(c, N, M; lcon = -Inf, ucon = Inf)
+        # Add forward diff: g[i,j] += x[i,j] - x[i+1,j]
+        c, _ = add_con!(c, g[i, j] += x[i, j] - x[i+1, j] for (i, j) in itr_fwd)
+        # Add backward diff: g[i,j] += x[i-1,j] - x[i,j]  (cancels forward for interior rows)
+        c, _ = add_con!(c, g[i, j] += x[i-1, j] - x[i, j] for (i, j) in itr_bwd)
+        m = ExaModel(c)
+        @test m.meta.ncon == N * M
+        @test m.meta.nnzj == (length(itr_fwd) + length(itr_bwd)) * 2
+
+        # Interior rows 2..N-1 get both augmentations: (x[i,j]-x[i+1,j]) + (x[i-1,j]-x[i,j])
+        # = x[i-1,j] - x[i+1,j]
+        # Row 1: only forward diff:  x[1,j] - x[2,j]
+        # Row N: only backward diff: x[N-1,j] - x[N,j]
+        x0 = ExaModels.convert_array(collect(Float64, 1:N*M), backend)
+        g_vals = Array(NLPModels.cons(m, x0))
+        for j = 1:M, i = 1:N
+            k = (j - 1) * N + i
+            xval = (j - 1) * N  # base for column j
+            if i == 1
+                expected = Float64(xval + 1) - Float64(xval + 2)
+            elseif i == N
+                expected = Float64(xval + N - 1) - Float64(xval + N)
+            else
+                expected = Float64(xval + i - 1) - Float64(xval + i + 1)
+            end
+            @test g_vals[k] ≈ expected
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,3 +50,8 @@ include("TwoStageTest/TwoStageTest.jl")
     # OptimalControlTest.runtests()
 
 end
+
+# Force full GC before Julia exits so that OpenCL/PoCL objects are finalized
+# in the correct order, preventing segfaults during Julia's atexit teardown.
+GC.gc(true)
+GC.gc(true)


### PR DESCRIPTION
The original syntax is
```julia
add_con!(core, c1, i => f(j) for (i,j) in itr)
```
This PR adds the following syntax
```julia
add_con!(core, c1[i] += f(j) for (i,j) in itr)
```
close #247 