### PR TITLE
CI: restrict benchmark compare job to PRs only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,7 +251,7 @@ jobs:
 
   compare:
     needs: [bench-nothing, bench-cuda, bench-amdgpu, bench-oneapi]
-    if: always() && contains(needs.*.result, 'success')
+    if: always() && github.event_name == 'pull_request' && contains(needs.*.result, 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The bench-* jobs are already guarded by `github.event_name ==
'pull_request'`, but the downstream `compare` job relied on implicit
skip propagation. Add an explicit PR-only guard so benchmarks never run
on push to main.