### PR TITLE
Missing renaming ParSource -> DataSource

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -49,7 +49,7 @@ end
 Base.show(io::IO, s::Expression) = _show_expression(io, s)
 function _show_expression(io::IO, s::Expression)
     expr = try
-        _expr_string(s.f(ParSource()))
+        _expr_string(s.f(DataSource()))
     catch
         "(?)"
     end

--- a/test/PrettyPrintTest.jl
+++ b/test/PrettyPrintTest.jl
@@ -56,6 +56,15 @@ function runtests()
             @test occursin("Node2{+}", s)
             @test occursin("sin(x[1])", s)
         end
+
+        @testset "Expression show" begin
+            c3 = ExaCore(concrete = Val(true))
+            c3, y = add_var(c3, 3)
+            c3, expr = add_expr(c3, y[i]^2 for i in 1:3)
+            s = sprint(show, expr)
+            @test occursin("Subexpression", s)
+            @test occursin("x[i]^2", s)
+        end
     end
 end
 


### PR DESCRIPTION
Seems to have been overlooked in https://github.com/exanauts/ExaModels.jl/pull/234 because it's not covered so I added a test as well.
Before the fix, the tests fail with
```
Expression show: Test Failed at /home/blegat/.julia/dev/ExaModels/test/PrettyPrintTest.jl:66
  Expression: occursin("x[i]^2", s)
   Evaluated: occursin("x[i]^2", "Subexpression (reduced)\n\n  s ∈ R^{3}\n  s(x,i) = (?)\n")

Stacktrace:
 [1] macro expansion
   @ ~/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/share/julia/stdlib/v1.12/Test/src/Test.jl:680 [inlined]
 [2] macro expansion
   @ ~/.julia/dev/ExaModels/test/PrettyPrintTest.jl:66 [inlined]
 [3] macro expansion
   @ ~/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/share/julia/stdlib/v1.12/Test/src/Test.jl:1777 [inlined]
 [4] macro expansion
   @ ~/.julia/dev/ExaModels/test/PrettyPrintTest.jl:61 [inlined]
 [5] macro expansion
   @ ~/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/share/julia/stdlib/v1.12/Test/src/Test.jl:1777 [inlined]
 [6] runtests()
   @ Main.PrettyPrintTest ~/.julia/dev/ExaModels/test/PrettyPrintTest.jl:7
Test Summary:             | Pass  Fail  Total  Time
Pretty printing           |   20     1     21  1.1s
  Node expression strings |    6            6  0.0s
  Identity simplification |    3            3  0.0s
  Iteration variable      |    2            2  0.0s
  Named variable          |    1            1  0.0s
  Short type display      |    3            3  0.0s
  fulltype                |    2            2  0.0s
  text/plain display      |    2            2  0.0s
  Expression show         |    1     1      2  1.1s
RNG of the outermost testset: Random.Xoshiro(0x085defaad30a5b0b, 0xc1c8ab81210a72db, 0x9e5d90e6597cada8, 0xe7974433e4535afb, 0xbaaea41933e094c1)
ERROR: Some tests did not pass: 20 passed, 1 failed, 0 errored, 0 broken.
```