### PR TITLE
nlp: add get_value/set_value! and standard getters/setters

### DIFF
--- a/src/ExaModels.jl
+++ b/src/ExaModels.jl
@@ -87,6 +87,18 @@ export ExaModel,
     exa_sum,
     exa_prod,
     @register_univariate,
-    @register_bivariate
+    @register_bivariate,
+    get_value,
+    set_value!,
+    get_start,
+    set_start!,
+    get_lvar,
+    set_lvar!,
+    get_uvar,
+    set_uvar!,
+    get_lcon,
+    set_lcon!,
+    get_ucon,
+    set_ucon!
 
 end # module ExaModels

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -704,17 +704,17 @@ end
 
 
 """
-    add_par(core, dims...; start = 0, name = nothing, tag = nothing)
-    add_par(core, start::AbstractArray; name = nothing, tag = nothing)
+    add_par(core, dims...; value = 0, name = nothing, tag = nothing)
+    add_par(core, value::AbstractArray; name = nothing, tag = nothing)
 
 Adds parameters to `core` and returns `(core, Parameter)`.
 
 The first form specifies dimensions with `dims` (each an `Integer` or
-`UnitRange`) and initial values via the `start` keyword. The second form
-is a convenience that uses `size(start)` as the dimensions.
+`UnitRange`) and initial values via the `value` keyword. The second form
+is a convenience that uses `size(value)` as the dimensions.
 
 ## Keyword Arguments
-- `start`: Initial parameter values. Can be a `Number`, `AbstractArray`, or `Generator`.
+- `value`: Initial parameter values. Can be a `Number`, `AbstractArray`, or `Generator`.
 - `name` : When given as `Val(:name)`, registers the parameter in `core` for later retrieval as `core.name` or `model.name`. See [`@add_par`](@ref) for the idiomatic named interface.
 - `tag`  : User-defined metadata attached to the parameter block.
 
@@ -732,16 +732,16 @@ Parameter
   θ ∈ R^{10}
 ```
 """
-@inline function add_par(c::C, start::AbstractArray; tag = nothing, name = nothing) where {T,C<:ExaCore{T}}
-    _add_par(c, tag, name, start, Base.size(start)...)
+@inline function add_par(c::C, value::AbstractArray; tag = nothing, name = nothing) where {T,C<:ExaCore{T}}
+    _add_par(c, tag, name, value, Base.size(value)...)
 end
 
-@inline function add_par(c::C, n::AbstractRange; tag = nothing, name = nothing, start = zero(T)) where {T,C<:ExaCore{T}}
-    _add_par(c, tag, name, start, n)
+@inline function add_par(c::C, n::AbstractRange; tag = nothing, name = nothing, value = zero(T)) where {T,C<:ExaCore{T}}
+    _add_par(c, tag, name, value, n)
 end
 
-@inline function add_par(c::C, ns...; tag = nothing, name = nothing, start = zero(T)) where {T,C<:ExaCore{T}}
-    _add_par(c, tag, name, start, ns...)
+@inline function add_par(c::C, ns...; tag = nothing, name = nothing, value = zero(T)) where {T,C<:ExaCore{T}}
+    _add_par(c, tag, name, value, ns...)
 end
 
 @inline function _add_par(c, tag, name, start, ns...)
@@ -784,6 +784,129 @@ function set_parameter!(c::ExaCore, param::Parameter, values::AbstractArray)
     copyto!(@view(c.θ[start_idx:end_idx]), values)
 
     return nothing
+end
+
+"""
+    get_value(model, param)
+
+Return a view of all values for `param` in `model.θ`.
+"""
+function get_value(model::ExaModel, param::Parameter)
+    return view(model.θ, param.offset+1 : param.offset+param.length)
+end
+
+"""
+    set_value!(model, param, values)
+
+Update all values for `param` in `model.θ` to `values`.
+"""
+function set_value!(model::ExaModel, param::Parameter, values)
+    if length(values) != param.length
+        throw(DimensionMismatch(
+            "expected $(param.length) elements, got $(length(values))"
+        ))
+    end
+    copyto!(view(model.θ, param.offset+1:param.offset+param.length), values)
+    return nothing
+end
+
+@inline _var_range(v::Variable)    = v.offset+1 : v.offset+v.length
+@inline _con_range(c::Constraint)  = c.offset+1 : c.offset+total(c.size)
+
+@inline function _check_len(got, expected, label)
+    got == expected || throw(DimensionMismatch("$label: expected $expected elements, got $got"))
+end
+
+"""
+    get_start(model, var::Variable)
+    get_start(model, con::Constraint)
+
+Return a view of the initial-point values (`x0` for variables, `y0` for constraints).
+"""
+get_start(model::ExaModel, v::Variable)   = view(model.meta.x0,   _var_range(v))
+get_start(model::ExaModel, c::Constraint) = view(model.meta.y0,   _con_range(c))
+
+"""
+    get_lvar(model, var::Variable)
+
+Return a view of the lower bounds for `var`.
+"""
+get_lvar(model::ExaModel, v::Variable) = view(model.meta.lvar, _var_range(v))
+
+"""
+    get_uvar(model, var::Variable)
+
+Return a view of the upper bounds for `var`.
+"""
+get_uvar(model::ExaModel, v::Variable) = view(model.meta.uvar, _var_range(v))
+
+"""
+    get_lcon(model, con::Constraint)
+
+Return a view of the lower bounds for `con`.
+"""
+get_lcon(model::ExaModel, c::Constraint) = view(model.meta.lcon, _con_range(c))
+
+"""
+    get_ucon(model, con::Constraint)
+
+Return a view of the upper bounds for `con`.
+"""
+get_ucon(model::ExaModel, c::Constraint) = view(model.meta.ucon, _con_range(c))
+
+"""
+    set_start!(model, var::Variable, values)
+    set_start!(model, con::Constraint, values)
+
+Update the initial-point values in-place (`x0` for variables, `y0` for constraints).
+"""
+function set_start!(model::ExaModel, v::Variable, values)
+    _check_len(length(values), v.length, "set_start!")
+    copyto!(view(model.meta.x0, _var_range(v)), values)
+end
+function set_start!(model::ExaModel, c::Constraint, values)
+    _check_len(length(values), total(c.size), "set_start!")
+    copyto!(view(model.meta.y0, _con_range(c)), values)
+end
+
+"""
+    set_lvar!(model, var::Variable, values)
+
+Update the lower bounds for `var` in-place.
+"""
+function set_lvar!(model::ExaModel, v::Variable, values)
+    _check_len(length(values), v.length, "set_lvar!")
+    copyto!(view(model.meta.lvar, _var_range(v)), values)
+end
+
+"""
+    set_uvar!(model, var::Variable, values)
+
+Update the upper bounds for `var` in-place.
+"""
+function set_uvar!(model::ExaModel, v::Variable, values)
+    _check_len(length(values), v.length, "set_uvar!")
+    copyto!(view(model.meta.uvar, _var_range(v)), values)
+end
+
+"""
+    set_lcon!(model, con::Constraint, values)
+
+Update the lower bounds for `con` in-place.
+"""
+function set_lcon!(model::ExaModel, c::Constraint, values)
+    _check_len(length(values), total(c.size), "set_lcon!")
+    copyto!(view(model.meta.lcon, _con_range(c)), values)
+end
+
+"""
+    set_ucon!(model, con::Constraint, values)
+
+Update the upper bounds for `con` in-place.
+"""
+function set_ucon!(model::ExaModel, c::Constraint, values)
+    _check_len(length(values), total(c.size), "set_ucon!")
+    copyto!(view(model.meta.ucon, _con_range(c)), values)
 end
 
 """

--- a/test/GetterSetterTest/GetterSetterTest.jl
+++ b/test/GetterSetterTest/GetterSetterTest.jl
@@ -1,0 +1,97 @@
+module GetterSetterTest
+
+using Test, ExaModels
+
+function build_model()
+    c = ExaCore(concrete = Val(true))
+    c, x  = add_var(c, 3; start = 1.0, lvar = -2.0, uvar = 5.0)
+    c, y  = add_var(c, 2; start = 0.5, lvar =  0.0, uvar = 1.0)
+    c, θ1 = add_par(c, [10.0, 20.0, 30.0])
+    c, θ2 = add_par(c, 2; value = 7.0)
+    c, g  = add_con(c, x[i] + x[i+1] for i in 1:2; lcon = -1.0, ucon = 1.0, start = 0.1)
+    c, h  = add_con(c, y[1] - y[2]; lcon = 0.0, ucon = 0.0, start = 0.5)
+    return ExaModel(c), x, y, θ1, θ2, g, h
+end
+
+function runtests()
+    @testset "Getter/setter API" begin
+
+        m, x, y, θ1, θ2, g, h = build_model()
+
+        @testset "get_value — parameters" begin
+            @test get_value(m, θ1) == [10.0, 20.0, 30.0]
+            @test get_value(m, θ2) == [7.0, 7.0]
+        end
+
+        @testset "set_value! — parameters" begin
+            set_value!(m, θ1, [1.0, 2.0, 3.0])
+            @test get_value(m, θ1) == [1.0, 2.0, 3.0]
+
+            set_value!(m, θ2, [9.0, 8.0])
+            @test get_value(m, θ2) == [9.0, 8.0]
+
+            @test_throws DimensionMismatch set_value!(m, θ1, [1.0, 2.0])
+            @test_throws DimensionMismatch set_value!(m, θ2, [1.0])
+        end
+
+        @testset "get_start / get_lvar / get_uvar — variables" begin
+            @test get_start(m, x) == [1.0, 1.0, 1.0]
+            @test get_lvar(m, x)  == [-2.0, -2.0, -2.0]
+            @test get_uvar(m, x)  == [5.0, 5.0, 5.0]
+            @test get_start(m, y) == [0.5, 0.5]
+            @test get_lvar(m, y)  == [0.0, 0.0]
+            @test get_uvar(m, y)  == [1.0, 1.0]
+        end
+
+        @testset "set_start! / set_lvar! / set_uvar! — variables" begin
+            set_start!(m, x, [2.0, 3.0, 4.0])
+            @test get_start(m, x) == [2.0, 3.0, 4.0]
+
+            set_lvar!(m, x, [-5.0, -6.0, -7.0])
+            @test get_lvar(m, x) == [-5.0, -6.0, -7.0]
+
+            set_uvar!(m, x, [10.0, 11.0, 12.0])
+            @test get_uvar(m, x) == [10.0, 11.0, 12.0]
+
+            @test_throws DimensionMismatch set_start!(m, x, [1.0])
+            @test_throws DimensionMismatch set_lvar!(m, x,  [1.0])
+            @test_throws DimensionMismatch set_uvar!(m, x,  [1.0])
+        end
+
+        @testset "get_start / get_lcon / get_ucon — constraints" begin
+            @test get_start(m, g) == [0.1, 0.1]
+            @test get_lcon(m, g)  == [-1.0, -1.0]
+            @test get_ucon(m, g)  == [1.0, 1.0]
+            @test get_start(m, h) == [0.5]
+            @test get_lcon(m, h)  == [0.0]
+            @test get_ucon(m, h)  == [0.0]
+        end
+
+        @testset "set_start! / set_lcon! / set_ucon! — constraints" begin
+            set_start!(m, g, [0.9, 0.8])
+            @test get_start(m, g) == [0.9, 0.8]
+
+            set_lcon!(m, g, [-3.0, -4.0])
+            @test get_lcon(m, g) == [-3.0, -4.0]
+
+            set_ucon!(m, g, [3.0, 4.0])
+            @test get_ucon(m, g) == [3.0, 4.0]
+
+            set_start!(m, h, [0.2])
+            @test get_start(m, h) == [0.2]
+
+            @test_throws DimensionMismatch set_start!(m, g, [1.0])
+            @test_throws DimensionMismatch set_lcon!(m, g,  [1.0])
+            @test_throws DimensionMismatch set_ucon!(m, g,  [1.0])
+        end
+
+        @testset "get_value returns a view (mutations visible)" begin
+            v = get_value(m, θ1)
+            v[1] = 99.0
+            @test get_value(m, θ1)[1] == 99.0
+        end
+
+    end
+end
+
+end # module GetterSetterTest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ include("JuMPTest/JuMPTest.jl")
 include("UtilsTest/UtilsTest.jl")
 include("JuliaCTest/JuliaCTest.jl")
 include("PrettyPrintTest.jl")
+include("GetterSetterTest/GetterSetterTest.jl")
 # include("OptimalControlTest/OptimalControlTest.jl")
 
 @testset verbose = true "ExaModels test" begin
@@ -45,6 +46,9 @@ include("PrettyPrintTest.jl")
 
     @info "Running PrettyPrint Test"
     PrettyPrintTest.runtests()
+
+    @info "Running Getter/Setter Test"
+    GetterSetterTest.runtests()
 
     # @info "Running OptimalControl Test"
     # OptimalControlTest.runtests()


### PR DESCRIPTION
## Summary

- Rename `add_par` keyword `start` → `value` for parameter initial values (consistent with getter naming)
- `get_value(model, param)` / `set_value!(model, param, values)` — view and update a parameter block in `model.θ`
- `get_start` / `set_start!` — `x0` for `Variable`, `y0` for `Constraint`
- `get_lvar` / `set_lvar!` / `get_uvar` / `set_uvar!` — variable bounds
- `get_lcon` / `set_lcon!` / `get_ucon` / `set_ucon!` — constraint bounds

All getters return `view`s into the underlying model arrays (zero-copy). Setters use `copyto!` with a `DimensionMismatch` guard.

## Test plan

- [ ] Verify `add_par` still works with positional `AbstractArray` and with the renamed `value` keyword
- [ ] Smoke-test each getter/setter on a small model

🤖 Generated with [Claude Code](https://claude.com/claude-code)