### PR TITLE
CI: run self-hosted jobs only on this repository's own runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on:
-      labels: cuda13
+      labels: [self-hosted, gpu, cuda, examodels]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         julia-version: ['1', 'lts']
         julia-arch: [x64]
         os: [ubuntu-latest]
-    runs-on: ['self-hosted']
+    runs-on: ['self-hosted', 'examodels']
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -83,11 +83,11 @@ jobs:
         julia-version: ['1', 'lts']
         julia-arch: [x64]
         os: [ubuntu-latest]
-        backend: ['cuda13', 'amdgpu', 'oneapi']
+        backend: ['cuda', 'amdgpu', 'oneapi']
         exclude:
           - julia-version: 'lts'
             backend: 'oneapi'
-    runs-on: ['self-hosted', 'gpu', '${{ matrix.backend }}']
+    runs-on: ['self-hosted', 'gpu', '${{ matrix.backend }}', 'examodels']
     continue-on-error: ${{ matrix.backend == 'oneapi' }}
     env:
       # oneAPI specific variables
@@ -114,7 +114,7 @@ jobs:
       run: |
         julia --startup-file=no --project=test -e 'using Pkg; Pkg.add("AMDGPU")'
     - name: Add CUDA.jl to test environment
-      if: matrix.backend == 'cuda13'
+      if: matrix.backend == 'cuda'
       run: |
         julia --startup-file=no --project=test -e 'using Pkg; Pkg.add("CUDA")'
     - name: Add oneAPI.jl to test environment
@@ -137,7 +137,7 @@ jobs:
         julia-arch: [aarch64]
         os: [macos-latest]
         backend: ['metal']
-    runs-on: ['self-hosted', 'gpu', '${{ matrix.backend }}']
+    runs-on: ['self-hosted', 'gpu', '${{ matrix.backend }}', 'examodels']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -170,7 +170,7 @@ jobs:
   bench-nothing:
     if: github.event_name == 'pull_request'
     needs: [github, cpu, gpu, metal]
-    runs-on: ['self-hosted']
+    runs-on: ['self-hosted', 'examodels']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
@@ -195,7 +195,7 @@ jobs:
   bench-cuda:
     if: github.event_name == 'pull_request'
     needs: [github, cpu, gpu, metal]
-    runs-on: ['self-hosted', 'gpu', 'cuda13']
+    runs-on: ['self-hosted', 'gpu', 'cuda', 'examodels']
     env:
       # opt out of MPS on the self-hosted runner
       CUDA_MPS_PIPE_DIRECTORY: /tmp/no-mps-${{ github.run_id }}
@@ -223,7 +223,7 @@ jobs:
   bench-amdgpu:
     if: github.event_name == 'pull_request'
     needs: [github, cpu, gpu, metal]
-    runs-on: ['self-hosted', 'gpu', 'amdgpu']
+    runs-on: ['self-hosted', 'gpu', 'amdgpu', 'examodels']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
@@ -248,7 +248,7 @@ jobs:
   bench-oneapi:
     if: github.event_name == 'pull_request'
     needs: [github, cpu, gpu, metal]
-    runs-on: ['self-hosted', 'gpu', 'oneapi']
+    runs-on: ['self-hosted', 'gpu', 'oneapi', 'examodels']
     continue-on-error: true
     env:
       OverrideDefaultFP64Settings: '1'


### PR DESCRIPTION
The organization shares runners into this repo via the Default runner group. Every self-hosted job here was reachable by them — **9 job definitions**, including the two that ask for nothing but `self-hosted`.

Those boxes cannot check out this repository: their git rewrites `github.com` to SSH, so `actions/checkout` dies with `git@github.com: Permission denied (publickey)` before Julia starts. Every job scheduled onto a `kkt*` runner has failed ([example](https://github.com/exanauts/ExaModels.jl/actions/runs/31397902218/job/93485649079?pr=294)).

GitHub matches runner labels only positively — there is no way to exclude — and the shared runners' label sets are supersets of ours, so no `runs-on` expression could pick ours and skip theirs. Each self-hosted job therefore also asks for **`examodels`**, a label only this repository's own runners carry. Dropping that one label from a job opts it back in.

### `cuda13` → `cuda`

The CUDA jobs asked for `cuda13`, which **only the shared runners carry** — so they had no eligible runner of ours at all. They now ask for `cuda`, carried by `examodels-1` and `examodels-3`.

This also repairs the backend token. The job does `push!(ARGS, "EXAMODELS_TEST_" * uppercase("${{ matrix.backend }}"))` and `test/backends.jl:17` tests for `EXAMODELS_TEST_CUDA` — so with the backend named `cuda13` it pushed `EXAMODELS_TEST_CUDA13`, which matches nothing, and **the CUDA test set has been silently skipped since #243**. Expect this job to exercise CUDA for the first time since then, and to take longer or surface real failures.

### Checked

Each `runs-on` was resolved against the live label sets of both the repo runners and the shared org runners:

| | jobs an org runner can take | jobs with no eligible runner |
|---|---|---|
| `main` | 9 | 0 |
| this branch | **0** | **0** |