### PR TITLE
CI: skip juliac AOT tests on the Windows leg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,13 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - name: Run tests
+        env:
+          # juliac needs a C toolchain to link the AOT executable, and the
+          # hosted Windows image has no C runtime headers on the include path:
+          # every `juliac compiles ...` test dies with
+          # `julia/libsupport.h:8:10: fatal error: stdlib.h: No such file or
+          # directory`. Skip AOT there, as the self-hosted legs already do.
+          EXAMODELS_SKIP_AOT: ${{ matrix.os == 'windows-latest' && '1' || '' }}
         run: |
           julia --startup-file=no --color=yes --code-coverage=user --project=./test -e '
             using Pkg


### PR DESCRIPTION
The `github (1, x64, windows-latest)` job fails on `main` and on every open pull request. It is not a regression from any of them — the hosted Windows image has no C runtime headers on the include path, so each of the three AOT tests dies while linking the juliac executable:

```
C:\hostedtoolcache\windows\julia\1.12.6\x64\include\julia/libsupport.h:8:10:
fatal error: stdlib.h: No such file or directory
```

The `lts` leg is green for an unrelated reason, not because it skips AOT: `JuliaC.ImageRecipe` is undefined there, so `_compile_exe` returns early without attempting a compile and each `@test compiled skip=!_HAS_JULIAC_API` is recorded as broken. No compile is attempted, so the missing toolchain never surfaces.

This sets `EXAMODELS_SKIP_AOT` for the Windows leg of the `github` job, matching what the self-hosted `cpu` and `gpu` jobs already do. `JuliaCTest` gates on `get(ENV, "EXAMODELS_SKIP_AOT", "") != ""`, so the expression yields `1` on Windows and an empty value elsewhere — the Linux legs are unaffected and juliac coverage there is unchanged.

Verified on this PR: both Windows legs pass, and their logs contain the `Skipping AOT tests` message with the AOT testset reporting 0 tests.
