### PR TITLE
Make non-concrete (low-latency) model construction the default

### DIFF
--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -13,7 +13,7 @@ open — and the compiled library resolves them per instance:
 ```julia
 using ExaModels, ExaModelsC
 
-c, N = ExaCore(concrete = Val(true), nargs = Val(1))
+c, N = ExaCore(nargs = Val(1))
 @add_var(c, x, N; start = 1.0)
 @add_obj(c, (x[i] - 1)^2 for i in 1:N)
 
@@ -189,7 +189,7 @@ function compile_library(
 end
 
 
-# A core built with `concrete = Val(false)` accumulates its blocks in
+# A core built in the default (non-concrete) mode accumulates its blocks in
 # `Vector{Any}` rather than in its own type. That is what makes model
 # construction cheap, and it is also what `juliac --trim=safe` cannot digest:
 # the model type is not statically known, so the call graph will not resolve.
@@ -197,20 +197,12 @@ end
 # It does not have to be compiled in that form, though. The core travels into
 # the generated app as serialized DATA, and the blocks inside those vectors are
 # already concretely typed — only the container is erased. Rebuilding it with
-# tuple storage costs one splat per accumulator, happens once here in the
-# caller's process, and hands the generator exactly the artifact it gets from a
-# `Val(true)` core. So a user can build the model in the fast mode and still
-# compile it.
-function _concretize(core::ExaModels.ExaCore)
-    all(getfield(core, f) isa Tuple for f in (:var, :par, :obj, :cons)) && return core
-    return ExaModels.ExaCore(
-        core;
-        var = (core.var...,),
-        par = (core.par...,),
-        obj = (core.obj...,),
-        cons = (core.cons...,),
-    )
-end
+# tuple storage happens once here in the caller's process, and hands the
+# generator exactly the artifact it gets from a `Val(true)` core. So a user
+# can build the model in the default mode and still compile it. The rebuild
+# itself lives in ExaModels (`_concretize`), where the `ExaModel` entry points
+# use it for the same purpose.
+_concretize(core::ExaModels.ExaCore) = ExaModels._concretize(core)
 
 # ── Where the library goes ────────────────────────────────────────────────────
 

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -156,6 +156,7 @@ function compile_library(
     verbose::Bool = false,
 )
     _check_prefix(prefix)
+    core = _concretize(core)
     isempty(args) && throw(
         ArgumentError(
             "give one example value per placeholder, as you would to " *
@@ -185,6 +186,30 @@ function compile_library(
     verbose && @info "compile_library: generated app" appdir
 
     return _drive_juliac(appdir, prefix, out, trim, bundle, verbose)
+end
+
+
+# A core built with `concrete = Val(false)` accumulates its blocks in
+# `Vector{Any}` rather than in its own type. That is what makes model
+# construction cheap, and it is also what `juliac --trim=safe` cannot digest:
+# the model type is not statically known, so the call graph will not resolve.
+#
+# It does not have to be compiled in that form, though. The core travels into
+# the generated app as serialized DATA, and the blocks inside those vectors are
+# already concretely typed — only the container is erased. Rebuilding it with
+# tuple storage costs one splat per accumulator, happens once here in the
+# caller's process, and hands the generator exactly the artifact it gets from a
+# `Val(true)` core. So a user can build the model in the fast mode and still
+# compile it.
+function _concretize(core::ExaModels.ExaCore)
+    all(getfield(core, f) isa Tuple for f in (:var, :par, :obj, :cons)) && return core
+    return ExaModels.ExaCore(
+        core;
+        var = (core.var...,),
+        par = (core.par...,),
+        obj = (core.obj...,),
+        cons = (core.cons...,),
+    )
 end
 
 # ── Where the library goes ────────────────────────────────────────────────────

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -12,8 +12,11 @@ import NLPModelsIpopt
 #
 # written exactly as it would be without `arg`, except that the size is left
 # open.  `build` is called twice below — once to compile, once to produce the
-# in-Julia reference the library is checked against.
-function build(cn = ExaCore(concrete = Val(true), nargs = Val(1)))
+# in-Julia reference the library is checked against.  The default core is the
+# default (non-concrete) mode on purpose: compiling from it is what proves
+# `_concretize` hands juliac the same artifact a `Val(true)` core produces
+# (the `Val(true)` compile path is covered by the main suite's app tests).
+function build(cn = ExaCore(nargs = Val(1)))
     c, N = cn
     @add_var(c, x, N; start = 1.0)
     @add_obj(c, (x[i] - 2.0)^2 for i in 1:N)

--- a/docs/src/patterns.md
+++ b/docs/src/patterns.md
@@ -6,12 +6,12 @@ especially when writing model-building functions.
 
 ## How the Macros Work
 
-In ExaModels v0.10, `ExaCore` (created with `concrete = Val(true)`) is an
-**immutable** struct. Every model-building call --- `add_var`, `add_obj`,
-`add_con`, etc. --- returns a **new** core rather than modifying the old one:
+Since ExaModels v0.10, `ExaCore` is an **immutable** struct. Every
+model-building call --- `add_var`, `add_obj`, `add_con`, etc. --- returns a
+**new** core rather than modifying the old one:
 
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 c, x = add_var(c, 10)       # c is rebound to a new ExaCore
 c, _ = add_obj(c, x[i]^2 for i in 1:10)  # c is rebound again
 ```
@@ -20,7 +20,7 @@ The `@add_var`-family macros are thin wrappers that do the same thing
 behind the scenes --- they **rebind** the core variable in the calling scope:
 
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10)          # expands to: c, x = add_var(c, 10)
 @add_obj(c, x[i]^2 for i in 1:10)  # expands to: c, _ = add_obj(c, ...)
 ```
@@ -39,7 +39,7 @@ accumulated model information:
 ```julia
 # WRONG --- the caller gets nothing useful
 function build_model_wrong()
-    c = ExaCore(concrete = Val(true))
+    c = ExaCore()
     @add_var(c, x, 10)
     @add_obj(c, x[i]^2 for i in 1:10)
     @add_con(c, x[i] + x[i+1] for i in 1:9)
@@ -53,7 +53,7 @@ at the end of the function:
 ```julia
 # CORRECT --- return the ExaModel (or core) to the caller
 function build_model()
-    c = ExaCore(concrete = Val(true))
+    c = ExaCore()
     @add_var(c, x, 10)
     @add_obj(c, x[i]^2 for i in 1:10)
     @add_con(c, x[i] + x[i+1] for i in 1:9)
@@ -78,7 +78,7 @@ function add_dynamics!(c, x, u, data)
 end
 
 function full_model()
-    c = ExaCore(concrete = Val(true))
+    c = ExaCore()
     @add_var(c, x, 11)
     @add_var(c, u, 10)
     c = add_dynamics!(c, x, u, data)   # rebind c with the returned core

--- a/docs/src/upgrade.md
+++ b/docs/src/upgrade.md
@@ -26,23 +26,21 @@ functional style (`c, x = add_var(c, ...)`) or the macro style
 | `objective(c, ...)` | `add_obj(c, ...)` → returns `(c, obj)` | `@add_obj(c, f, ...)` |
 | `subexpr(c, ...)` | `add_expr(c, ...)` → returns `(c, expr)` | `@add_expr(c, s, ...)` |
 
-### 2. `ExaCore` and `LegacyExaCore`
+### 2. `ExaCore` is immutable
 
 In v0.9, `ExaCore` was a mutable struct that was modified in-place by each
 model-building call.
 
-In v0.10, `ExaCore` is an immutable struct.  For backward compatibility,
-`ExaCore()` (i.e. `concrete = Val(false)`, the default) returns a
-`LegacyExaCore` — a thin mutable wrapper that supports the deprecated mutating
-wrappers (`variable`, `parameter`, `objective`, `constraint`, `constraint!`,
-`subexpr`).  A deprecation warning is emitted at construction time to signal
-that this path will be removed in a future release.
+Since v0.10, `ExaCore` is an immutable struct: every model-building call
+returns a new core, and the old mutating wrappers (`variable`, `parameter`,
+`objective`, `constraint`, `constraint!`, `subexpr`) have been removed.
 
-Note that `LegacyExaCore` does **not** support the new functional `add_*` API.
-Migrate to `ExaCore(concrete = Val(true))` to use `add_var`, `add_obj`, etc.
-
-To obtain the bare immutable `ExaCore` — required for type-stable code and AOT
-compilation with `juliac` — pass `concrete = Val(true)`:
+The `concrete` keyword selects how the core accumulates blocks.  The default,
+`concrete = Val(false)`, uses type-erased storage: the core's type does not
+change as blocks are added, so model construction compiles once instead of
+once per block.  Pass `concrete = Val(true)` to keep every block in the
+core's type, which is required for AOT compilation with `juliac --trim=safe`.
+Both modes produce the same `ExaModel`:
 
 ```julia
 # v0.9
@@ -52,13 +50,13 @@ objective(c, x[i]^2 for i in 1:10)
 m = ExaModel(c)
 
 # v0.10 — functional style (recommended)
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 c, x = add_var(c, 10; lvar = 0.0)
 c, _  = add_obj(c, x[i]^2 for i in 1:10)
 m = ExaModel(c)
 
 # v0.10 — macro style (most concise)
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10; lvar = 0.0)
 @add_obj(c, x[i]^2 for i in 1:10)
 m = ExaModel(c)
@@ -87,7 +85,7 @@ c = ExaCore()
 x = variable(c, ...)
 
 # New: functional pair destructuring, c rebound to updated immutable
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 c, x = add_var(c, ...)
 ```
 
@@ -111,7 +109,7 @@ m = ExaModel(c)
 using ExaModels
 
 n = 100
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 c, x = add_var(c, n; lvar = -1.0, uvar = 1.0, start = 0.0)
 c, θ = add_par(c, ones(n))
 c, s = add_expr(c, θ[i] * x[i]^2 for i in 1:n)
@@ -124,7 +122,7 @@ m = ExaModel(c)
 using ExaModels
 
 n = 100
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, n; lvar = -1.0, uvar = 1.0, start = 0.0)
 @add_par(c, θ, ones(n))
 @add_expr(c, s, θ[i] * x[i]^2 for i in 1:n)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -266,15 +266,22 @@ end
 abstract type AbstractExaCore{T,VT,B,S} end
 
 """
-    ExaCore([array_eltype::Type; backend = nothing, minimize = true, name = :Generic])
+    ExaCore([array_eltype::Type; backend = nothing, concrete = Val(false), minimize = true, name = :Generic])
 
 Creates an intermediate data object `ExaCore`, which later can be used for creating an `ExaModel`
+
+By default (`concrete = Val(false)`) the core accumulates model blocks in
+type-erased storage, so its type does not change as blocks are added and the
+model can be built — and rebuilt — without recompiling at every step. Pass
+`concrete = Val(true)` to keep every block in the core's type instead, which
+is what AOT compilation (`juliac --trim=safe`) requires. Both modes produce
+the same `ExaModel`.
 
 ## Example
 ```jldoctest
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true))
+julia> c = ExaCore()
 An ExaCore
 
   Float type: ...................... Float64
@@ -284,7 +291,7 @@ An ExaCore
   number of objective patterns: .... 0
   number of constraint patterns: ... 0
 
-julia> c = ExaCore(Float32; concrete = Val(true))
+julia> c = ExaCore(Float32)
 An ExaCore
 
   Float type: ...................... Float32
@@ -296,7 +303,7 @@ An ExaCore
 
 julia> using CUDA
 
-julia> c = ExaCore(Float32; backend = CUDABackend(), concrete = Val(true))
+julia> c = ExaCore(Float32; backend = CUDABackend())
 An ExaCore
 
   Float type: ...................... Float32
@@ -458,12 +465,13 @@ end
     )
 end
 
-# `concrete` now selects how the core accumulates blocks. `Val(true)` (and the
-# default) keeps every block in the core's type, which is what `juliac
-# --trim=safe` needs. `Val(false)` accumulates into `Vector{Any}` instead: the
-# core's type stops changing on each `add_*`, so the builder compiles once
-# instead of once per block, at the cost of AOT compilability. Both modes
-# produce the same `ExaModel` and the same AD kernels.
+# `concrete` selects how the core accumulates blocks. `Val(false)` — the
+# default — accumulates into `Vector{Any}`: the core's type stops changing on
+# each `add_*`, so the builder compiles once instead of once per block and the
+# model can be rebuilt without recompiling in every step. `Val(true)` keeps
+# every block in the core's type instead, which is what `juliac --trim=safe`
+# needs. `ExaModel` concretizes a `Vector{Any}` core at entry (`_concretize`),
+# so both modes produce the same `ExaModel` and the same AD kernels.
 
 @inline function ExaCore(
     ::Type{T}; backend = nothing, concrete = nothing, nargs = Val(0), kwargs...,
@@ -522,9 +530,26 @@ is known statically and destructuring stays inferable.
 
 # Storage selected by the `concrete` keyword. Called once per accumulator so
 # the four never alias the same vector.
-@inline _storage(::Nothing) = ()
+@inline _storage(::Nothing) = Any[]
 @inline _storage(::Val{true}) = ()
 @inline _storage(::Val{false}) = Any[]
+
+# Rebuild a `Vector{Any}`-storage core with tuple accumulators. The blocks
+# inside the vectors are already concretely typed — only the container is
+# erased — so this recovers a core indistinguishable from one built with
+# `concrete = Val(true)`. Every `ExaModel` entry point calls this first, so
+# downstream consumers (`build_extension`, the oracle build, `instantiate`)
+# only ever see tuple storage. Identity on a tuple core by dispatch, which
+# keeps the `Val(true)` path fully inferable for `juliac --trim=safe`.
+@inline _concretize(c::ExaCore) = _concretize(c, c.var, c.par, c.obj, c.cons)
+@inline _concretize(c::ExaCore, ::Tuple, ::Tuple, ::Tuple, ::Tuple) = c
+@inline _concretize(c::ExaCore, var, par, obj, cons) = ExaCore(
+    c;
+    var = _materialize(var),
+    par = _materialize(par),
+    obj = _materialize(obj),
+    cons = _materialize(cons),
+)
 
 @inline _exa_core_from_x0(x0, backend; kwargs...) =
     _exa_core(eltype(x0); x0, backend, kwargs...)
@@ -692,7 +717,7 @@ optimization solvers within `JuliaSmoothOptimizer` ecosystem, such as
 ```jldoctest
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));                           # create an ExaCore object
+julia> c = ExaCore();                           # create an ExaCore object
 
 julia> c, x = add_var(c, 1:10);               # create variables
 
@@ -725,12 +750,13 @@ julia> result = ipopt(m; print_level=0)    # solve the problem
 # No-oracle path: always returns ExaModel (type-stable for juliac --trim=safe).
 function ExaModel(c::ExaCore{T, VT, B, S, V, P, O, C, R, Tuple{}, Tuple{}, Tuple{}}; prod = false, kwargs...) where {T, VT, B, S, V, P, O, C, R}
     _recipe_check(c)
+    c = _concretize(c)
     return ExaModel(
         c.name,
-        _materialize(c.var),
-        _materialize(c.par),
-        _materialize(c.obj),
-        _materialize(c.cons),
+        c.var,
+        c.par,
+        c.obj,
+        c.cons,
         c.θ,
         NLPModels.NLPModelMeta(
             c.nvar,
@@ -755,7 +781,7 @@ end
 # Oracle path: always returns ExaModelWithOracle (type-stable for juliac --trim=safe).
 function ExaModel(c::ExaCore; prod = false, kwargs...)
     _recipe_check(c)
-    return _build_with_oracle(c; prod, kwargs...)
+    return _build_with_oracle(_concretize(c); prod, kwargs...)
 end
 
 """
@@ -772,7 +798,7 @@ a core with no argument dependency is built exactly as before.
 ```jldoctest
 julia> using ExaModels
 
-julia> c, N, v = ExaCore(concrete = Val(true), nargs = Val(2));
+julia> c, N, v = ExaCore(nargs = Val(2));
 
 julia> @add_var(c, x, N; start = v);
 
@@ -782,8 +808,11 @@ julia> m.meta.nvar, m.meta.x0
 (3, [1.0, 2.0, 3.0])
 ```
 """
+# Concretized before `instantiate`: the walk relies on block types, and
+# `_assert_instantiated` on the *core's* type — `Vector{Any}` storage would
+# hide leftover placeholders from both.
 function ExaModel(c::ExaCore, a, as...; check = Val(true), kwargs...)
-    return ExaModel(_assert_instantiated(check, instantiate(c, a, as...)); kwargs...)
+    return ExaModel(_assert_instantiated(check, instantiate(_concretize(c), a, as...)); kwargs...)
 end
 ExaModel(c::ExaCore, ::Nothing; kwargs...) = ExaModel(c; kwargs...)
 
@@ -995,7 +1024,7 @@ Adds variables with dimensions specified by `dims` to `core`. `dims` can be eith
 ```jldoctest
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 10; start = (sin(i) for i=1:10));
 
@@ -1064,7 +1093,7 @@ is a convenience that uses `size(value)` as the dimensions.
 ```jldoctest
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, θ = add_par(c, ones(10));
 
@@ -1104,7 +1133,7 @@ Updates the values of parameters in the core.
 ```jldoctest
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, p = add_par(c, ones(5));
 
@@ -1298,7 +1327,7 @@ Adds objective terms specified by a `generator` to `core`, and returns `(core, O
 ```julia
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 10);
 
@@ -1379,7 +1408,7 @@ then use [`add_con!`](@ref) / [`@add_con!`](@ref) to accumulate terms afterwards
 ```julia
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 10);
 
@@ -1399,7 +1428,7 @@ Empty constraint with augmentation:
 ```jldoctest
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 10);
 
@@ -1519,7 +1548,7 @@ Single-index augmentation — add `sin(x[i+1])` to constraint rows 4, 5, 6:
 ```julia
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 10);
 
@@ -1566,7 +1595,7 @@ Equivalent to `add_con!(core, g, idx => expr for ... in itr)`.
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 c, x = add_var(c, 10)
 c, g = add_con(c, 9; lcon = -1.0, ucon = 1.0)
 c, _ = add_con!(c, g[i] += x[i] + x[i+1] for i = 1:9)
@@ -1627,7 +1656,7 @@ variables or constraints are added to the problem.
 ```julia
 julia> using ExaModels
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 10);
 
@@ -1645,7 +1674,7 @@ julia> c, _ = add_obj(c, s[i] + s[i+1] for i in 1:9);
 ## Multi-dimensional example
 
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 c, x = add_var(c, 1:N, 1:K)
 itr = [(i, k) for i in 1:N, k in 1:K]
 c, s = add_expr(c, x[i, k]^2 for (i, k) in itr)
@@ -1894,7 +1923,7 @@ obtained by solving the model. The returned array has the same shape as `x`.
 ```jldoctest
 julia> using ExaModels, NLPModelsIpopt
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 1:10; lvar = -1, uvar = 1);
 
@@ -1931,7 +1960,7 @@ magnitude measures how much the objective would improve if that bound were relax
 ```jldoctest
 julia> using ExaModels, NLPModelsIpopt
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 1:10; lvar = -1, uvar = 1);
 
@@ -1968,7 +1997,7 @@ magnitude measures how much the objective would improve if that bound were relax
 ```jldoctest
 julia> using ExaModels, NLPModelsIpopt
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 1:10; lvar = -1, uvar = 1);
 
@@ -2003,7 +2032,7 @@ Returns the multipliers for constraints `y` associated with `result`, obtained b
 ```jldoctest
 julia> using ExaModels, NLPModelsIpopt
 
-julia> c = ExaCore(concrete = Val(true));
+julia> c = ExaCore();
 
 julia> c, x = add_var(c, 1:10; lvar = -1, uvar = 1);
 
@@ -2074,7 +2103,7 @@ Accepts the same keyword arguments as [`add_var`](@ref).
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10; lvar = -1, uvar = 1)  # x is now in scope; c.x also works
 @add_var(c, y, 1:5)                        # y is in scope; c.y also works
 ```
@@ -2125,7 +2154,7 @@ Macro interface for [`add_par`](@ref). Updates `core` in the calling scope.
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_par(c, θ, ones(10))  # θ is now in scope; c.θ also works
 ```
 """
@@ -2174,7 +2203,7 @@ Macro interface for [`add_obj`](@ref). Updates `core` in the calling scope.
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10)
 @add_obj(c, x[i]^2 for i in 1:10)
 ```
@@ -2226,7 +2255,7 @@ Accepts the same keyword arguments as [`add_con`](@ref) (`lcon`, `ucon`, `start`
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10)
 @add_con(c, g, x[i] + x[i+1] for i in 1:9; lcon = -1, ucon = 1)  # g in scope; c.g also works
 ```
@@ -2284,7 +2313,7 @@ See [`add_con!`](@ref) for full semantics and usage notes.
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10)
 @add_con(c, g, x[i] + x[i+1] for i in 1:9; lcon = -1, ucon = 1)
 
@@ -2365,7 +2394,7 @@ Macro interface for [`add_expr`](@ref). Updates `core` in the calling scope.
 
 ## Example
 ```julia
-c = ExaCore(concrete = Val(true))
+c = ExaCore()
 @add_var(c, x, 10)
 @add_expr(c, s, x[i]^2 for i in 1:10)    # s in scope; c.s also works
 @add_obj(c, s[i] + s[i+1] for i in 1:9)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -458,32 +458,27 @@ end
     )
 end
 
-# `concrete` chose between the immutable core and the deprecated mutable
-# wrapper. There is only the immutable one now, so `Val(true)` is accepted and
-# does nothing — that is the spelling every existing model and document uses,
-# and breaking all of them here would be gratuitous. `Val(false)` asked for the
-# core that no longer exists, so it says so rather than quietly handing back the
-# other one.
-@inline _concrete(::Nothing) = nothing
-@inline _concrete(::Val{true}) = nothing
-_concrete(::Val{false}) = throw(
-    ArgumentError(
-        "`concrete = Val(false)` selected the mutable `LegacyExaCore`, which has " *
-        "been removed. `ExaCore()` returns the immutable core — drop the keyword.",
-    ),
-)
+# `concrete` now selects how the core accumulates blocks. `Val(true)` (and the
+# default) keeps every block in the core's type, which is what `juliac
+# --trim=safe` needs. `Val(false)` accumulates into `Vector{Any}` instead: the
+# core's type stops changing on each `add_*`, so the builder compiles once
+# instead of once per block, at the cost of AOT compilability. Both modes
+# produce the same `ExaModel` and the same AD kernels.
 
 @inline function ExaCore(
     ::Type{T}; backend = nothing, concrete = nothing, nargs = Val(0), kwargs...,
 ) where {T<:AbstractFloat}
-    _concrete(concrete)
     return _with_args(
-        _exa_core_from_x0(convert_array(zeros(T, 0), backend), backend; kwargs...), nargs,
+        _exa_core_from_x0(
+            convert_array(zeros(T, 0), backend), backend;
+            var = _storage(concrete), par = _storage(concrete),
+            obj = _storage(concrete), cons = _storage(concrete), kwargs...,
+        ),
+        nargs,
     )
 end
 @inline function ExaCore(; backend = nothing, concrete = nothing, nargs = Val(0), kwargs...)
-    _concrete(concrete)
-    return ExaCore(default_T(backend); backend, nargs, kwargs...)
+    return ExaCore(default_T(backend); backend, concrete, nargs, kwargs...)
 end
 
 """
@@ -512,6 +507,25 @@ is known statically and destructuring stays inferable.
 # `eltype(x0)` — NOT the requested float type.  The two differ on backends that
 # promote (Metal turns Float64 into Float32), so the core's `T` is still taken
 # from the realised `x0` rather than from the caller's request.
+
+# --- accumulator storage -----------------------------------------------------
+# `_prep` appends a block to `var`/`par`/`obj`/`cons`; `_materialize` turns the
+# accumulator back into the concrete tuple `ExaModel` needs. Tuple storage puts
+# every block in the core's TYPE, so the type changes on each `add_*` and the
+# builder is recompiled for each one. `Vector{Any}` storage keeps the type
+# constant and defers the concrete tuple to a single `_materialize` call.
+@inline _prep(t::Tuple, x) = (x, t...)
+@inline _prep(v::Vector{Any}, x) = pushfirst!(copy(v), x)
+
+@inline _materialize(t::Tuple) = t
+@inline _materialize(v::Vector{Any}) = (v...,)
+
+# Storage selected by the `concrete` keyword. Called once per accumulator so
+# the four never alias the same vector.
+@inline _storage(::Nothing) = ()
+@inline _storage(::Val{true}) = ()
+@inline _storage(::Val{false}) = Any[]
+
 @inline _exa_core_from_x0(x0, backend; kwargs...) =
     _exa_core(eltype(x0); x0, backend, kwargs...)
 @inline ExaCore(c::C; kwargs...) where {T, C <: ExaCore{T}} = _exa_core(
@@ -713,10 +727,10 @@ function ExaModel(c::ExaCore{T, VT, B, S, V, P, O, C, R, Tuple{}, Tuple{}, Tuple
     _recipe_check(c)
     return ExaModel(
         c.name,
-        c.var,
-        c.par,
-        c.obj,
-        c.cons,
+        _materialize(c.var),
+        _materialize(c.par),
+        _materialize(c.obj),
+        _materialize(c.cons),
         c.θ,
         NLPModels.NLPModelMeta(
             c.nvar,
@@ -1022,7 +1036,7 @@ end
 
     v = Variable(ns, len, o, _val_name(name), tag)
 
-    (ExaCore(c; var = (v, c.var...), nvar=nvar, x0=x0, lvar=lvar, uvar=uvar, refs = add_refs(c.refs, name, v)), v)
+    (ExaCore(c; var = _prep(c.var, v), nvar=nvar, x0=x0, lvar=lvar, uvar=uvar, refs = add_refs(c.refs, name, v)), v)
 end
 
 @inline _val_name(::Val{N}) where {N} = N
@@ -1078,7 +1092,7 @@ end
     npar = c.npar + len
     θ = _append_slot(c.backend, c.θ, start, len)
     p = Parameter(ns, len, o, tag)
-    (ExaCore(c; par = (p, c.par...), θ=θ, npar=npar, refs = add_refs(c.refs, name, p)), p)
+    (ExaCore(c; par = _prep(c.par, p), θ=θ, npar=npar, refs = add_refs(c.refs, name, p)), p)
 end
 
 """
@@ -1333,7 +1347,7 @@ end
     nnzh = c.nnzh + nitr * f.o2step
 
     obj = Objective(f, convert_array(pars, c.backend))
-    (ExaCore(c; nobj=nobj, nnzg=nnzg, nnzh=nnzh, obj=(obj, c.obj...), refs = add_refs(c.refs, name, obj)), obj)
+    (ExaCore(c; nobj=nobj, nnzg=nnzg, nnzh=nnzh, obj=_prep(c.obj, obj), refs = add_refs(c.refs, name, obj)), obj)
 end
 
 
@@ -1462,7 +1476,7 @@ function _add_con(c, f, pars, dims, start, lcon, ucon, name, tag)
 
     con = Constraint(f, convert_array(pars, c.backend), o, dims, tag)
 
-    (ExaCore(c; ncon=ncon, nnzj=nnzj, nnzh=nnzh, y0=y0, lcon=lcon, ucon=ucon, cons=(con, c.cons...), refs = add_refs(c.refs, name, con)), con)
+    (ExaCore(c; ncon=ncon, nnzj=nnzj, nnzh=nnzh, y0=y0, lcon=lcon, ucon=ucon, cons=_prep(c.cons, con), refs = add_refs(c.refs, name, con)), con)
 end
 
 
@@ -1589,7 +1603,7 @@ function _add_con!(c, f, pars, dims, tag)
     nnzj = c.nnzj + nitr * f.o1step
     nnzh = c.nnzh + nitr * f.o2step
     con = ConstraintAugmentation(f, convert_array(pars, c.backend), oa, dims, tag)
-    (ExaCore(c; nconaug=nconaug, nnzj=nnzj, nnzh=nnzh, cons=(con, c.cons...)), con)
+    (ExaCore(c; nconaug=nconaug, nnzj=nnzj, nnzh=nnzh, cons=_prep(c.cons, con)), con)
 end
 
 # Helper to infer dimensions from iterator

--- a/src/oracle.jl
+++ b/src/oracle.jl
@@ -1288,7 +1288,7 @@ Returns `(core, evaluator)`.
 ## Example
 
 ```julia
-core = ExaCore(concrete = Val(true))
+core = ExaCore()
 @add_var(core, x, 4)
 c = @add_con(core, 0.0 * x[i] for i in 1:4; lcon = 0.0, ucon = 0.0)
 
@@ -1414,7 +1414,7 @@ output `Variable`.
 ## Example
 
 ```julia
-core = ExaCore(concrete = Val(true))
+core = ExaCore()
 @add_var(core, x, 2; start = [1.0, 1.0])
 
 core, z, _ = embed_oracle(core, x, 1;

--- a/test/ConcreteModeTest.jl
+++ b/test/ConcreteModeTest.jl
@@ -1,0 +1,69 @@
+module ConcreteModeTest
+
+using Test, ExaModels
+import NLPModels
+
+# The same small model (variables, parameters, a subexpression, constraints,
+# an augmentation, and an objective) built on either storage mode.
+function _build(; concrete)
+    n = 10
+    c = ExaCore(; concrete)
+    c, x = add_var(c, n; lvar = -1.0, uvar = 1.0, start = 0.5)
+    c, θ = add_par(c, ones(n))
+    c, s = add_expr(c, θ[i] * x[i]^2 for i in 1:n)
+    c, g = add_con(c, x[i] + x[i+1] for i in 1:n-1; lcon = -1.0, ucon = 1.0)
+    c, _ = add_con!(c, g, i => sin(x[i+1]) for i in 1:n-1)
+    c, _ = add_obj(c, s[i] for i in 1:n)
+    return c
+end
+
+function runtests()
+    @testset "Concrete mode" begin
+        @testset "default is type-erased storage" begin
+            c = ExaCore()
+            @test c.var isa Vector{Any}
+            @test c.par isa Vector{Any}
+            @test c.obj isa Vector{Any}
+            @test c.cons isa Vector{Any}
+            # The point of the erased storage: adding a block leaves the
+            # core's type unchanged, so the builder compiles once rather
+            # than once per block.
+            c1, x = add_var(c, 10)
+            @test typeof(c1) === typeof(c)
+            c2, _ = add_obj(c1, x[i]^2 for i in 1:10)
+            @test typeof(c2) === typeof(c1)
+        end
+
+        @testset "_concretize recovers the Val(true) core" begin
+            cf = _build(concrete = Val(false))
+            ct = _build(concrete = Val(true))
+            @test typeof(ExaModels._concretize(cf)) === typeof(ct)
+            # Identity on a core that is already concrete.
+            @test ExaModels._concretize(ct) === ct
+        end
+
+        @testset "both modes build the same model" begin
+            mf = ExaModel(_build(concrete = Val(false)))
+            mt = ExaModel(_build(concrete = Val(true)))
+            @test typeof(mf) === typeof(mt)
+            x = [0.1i for i in 1:10]
+            @test NLPModels.obj(mf, x) == NLPModels.obj(mt, x)
+            @test NLPModels.grad(mf, x) == NLPModels.grad(mt, x)
+            @test NLPModels.cons(mf, x) == NLPModels.cons(mt, x)
+            @test NLPModels.jac_coord(mf, x) == NLPModels.jac_coord(mt, x)
+            y = ones(mf.meta.ncon)
+            @test NLPModels.hess_coord(mf, x, y) == NLPModels.hess_coord(mt, x, y)
+        end
+
+        @testset "recipe core in default mode" begin
+            c, N = ExaCore(nargs = Val(1))
+            @add_var(c, x, N; start = 1.5)
+            @add_obj(c, (x[i] - 1)^2 for i in 1:N)
+            m = ExaModel(c, 4)
+            @test m.meta.nvar == 4
+            @test NLPModels.obj(m, m.meta.x0) ≈ 1.0
+        end
+    end
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ include("JuliaCTest/JuliaCTest.jl")
 include("TwoStageTest/TwoStageTest.jl")
 include("GetterSetterTest/GetterSetterTest.jl")
 include("PrettyPrintTest.jl")
+include("ConcreteModeTest.jl")
 # include("OptimalControlTest/OptimalControlTest.jl")
 include("OracleTest/OracleTest.jl")
 
@@ -54,6 +55,9 @@ include("OracleTest/OracleTest.jl")
 
     @info "Running PrettyPrint Test"
     PrettyPrintTest.runtests()
+
+    @info "Running Concrete Mode Test"
+    ConcreteModeTest.runtests()
 
     # @info "Running OptimalControl Test"
     # OptimalControlTest.runtests()


### PR DESCRIPTION
## Summary

Every `add_*` on an `ExaCore` used to return a core whose type embeds a tuple of all blocks added so far, so a model with K blocks produces K distinct core types, and the builder chain is inferred and compiled once per block. That cost is superlinear in K and dominates model creation: a model that takes milliseconds to rebuild in a warm session can take minutes to build the first time.

This PR adds a type-erased storage mode for `ExaCore` and makes it the default:

- **`concrete = Val(false)` (the new default).** Blocks accumulate in `Vector{Any}`, so the core's type does not change as blocks are added. The builder compiles once instead of once per block, and a model can be updated and rebuilt without recompiling at every step.
- **`concrete = Val(true)`.** The previous behavior — every block carried in the core's type — still available, and required when the core itself is what `juliac --trim=safe` compiles.

The blocks inside the erased containers remain concretely typed; only the container is erased. Every `ExaModel` entry point therefore rebuilds a non-concrete core with tuple storage first (`_concretize`, identity on already-concrete cores by dispatch, so the `Val(true)` path stays fully inferable). Both modes produce the same `ExaModel` and the same AD kernels on every backend, and `ExaModelsC.compile_library` accepts a core built in either mode — it concretizes before generating the app, and the libraries built from the two modes export identical symbol sets.

## Measurements

First build of a model-building function, fresh process, Julia 1.12.6:

|          | concrete | `Val(false)` |
|----------|----------|--------------|
| 16 vars  | 6.12 s   | 4.16 s       |
| 64 vars  | 22.00 s  | 4.45 s       |
| 8 cons   | 6.94 s   | 6.32 s       |
| 16 cons  | 9.72 s   | 8.13 s       |

On the GOC3 case, model construction drops from 26.1 min (concrete) to 2.1 min (non-concrete), with an identical compiled library at the end. Run-time AD on a 100k-variable model is unchanged (grad and jac within 1%).

## Compatibility

- The produced `ExaModel` is identical across modes — the test suite checks type equality of the built models and equality of `obj`/`grad`/`cons`/`jac_coord`/`hess_coord` between the two.
- Non-concrete cores previously worked only on the plain CPU path: the KernelAbstractions extension, the oracle build, and the recipe `instantiate` walk consumed the accumulators raw from the core (and the leftover-placeholder check, which reads the core's *type*, was blind through `Vector{Any}`). Concretizing at the `ExaModel` boundary fixes all three.
- AOT users compiling their own model-building functions with `juliac --trim=safe` should keep passing `concrete = Val(true)`; `ExaModelsC` users need no change.
- Docs updated accordingly (`upgrade.md`, `patterns.md`, docstrings).

## Tests

- New `test/ConcreteModeTest.jl`: default storage mode, core-type invariance under `add_*`, cross-mode model equality, and the recipe (`nargs`) path under the default mode.
- The `ExaModelsC` test model now builds in the default mode, so the compile-a-non-concrete-core path is exercised end-to-end (52 tests).
- `OracleTest` builds its cores without the `concrete` keyword and now exercises the default organically.
- GPU path verified on a GV100: a model built from a default-storage core with `CUDABackend()` matches the CPU model's `obj`/`grad`/`cons`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
