### PR TITLE
Take the pglib test cases from ExaPowerIO's artifact

### DIFF
--- a/test/NLPTest/NLPTest.jl
+++ b/test/NLPTest/NLPTest.jl
@@ -1,7 +1,7 @@
 module NLPTest
 
 using ExaModels
-using Downloads, Test
+using ExaPowerIO, Test
 using NLPModels, NLPModelsJuMP, NLPModelsIpopt, NLPModelsTest
 using JuMP, PowerModels, MadNLP, Percival
 
@@ -222,8 +222,6 @@ function runtests()
 end
 
 function __init__()
-    global TMPDIR = tempname()
-    mkdir(TMPDIR)
     PowerModels.silence()
 end
 

--- a/test/NLPTest/power.jl
+++ b/test/NLPTest/power.jl
@@ -1,19 +1,8 @@
+# The pglib cases come from ExaPowerIO's lazy artifact, so they are fetched by the
+# artifact machinery on first use and cached in the depot from then on.
 function get_power_case(filename)
-    if !isfile(filename)
-        ff = joinpath(TMPDIR, filename)
-        if !isfile(ff)
-            @info "Downloading $filename"
-            Downloads.download(
-                "https://raw.githubusercontent.com/power-grid-lib/pglib-opf/dc6be4b2f85ca0e776952ec22cbd4c22396ea5a3/$filename",
-                joinpath(TMPDIR, filename),
-            )
-            return joinpath(TMPDIR, filename)
-        else
-            return ff
-        end
-    else
-        return filename
-    end
+    isfile(filename) && return filename
+    return joinpath(ExaPowerIO.get_path(:pglib), filename)
 end
 
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,6 @@
 [deps]
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
+ExaPowerIO = "14903efe-9500-4d7f-a589-7ab7e15da6de"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"


### PR DESCRIPTION
The AC power tests download their pglib-opf case files from `raw.githubusercontent.com` into a fresh `tempname()` directory on every run, so a transient name-resolution failure on a runner errors the testsets outright:

```
ac_power pglib_opf_case3_lmbd.m: Error During Test
  Got exception outside of a @test
  RequestError: Could not resolve host: raw.githubusercontent.com while requesting
  https://raw.githubusercontent.com/power-grid-lib/pglib-opf/dc6be4.../pglib_opf_case3_lmbd.m
```

That takes out `ac_power pglib_opf_case3_lmbd.m`, `ac_power pglib_opf_case14_ieee.m` and `Parametric power` while the other 1419 tests pass, and it has hit both `main` and open PRs.

ExaPowerIO ships pglib-opf as a lazy artifact, so this takes the cases from there instead of fetching them by hand. The artifact machinery downloads them once and caches them in the depot (which `julia-actions/cache` already preserves), and the test suite no longer does any downloading of its own — `Downloads` and the `TMPDIR` global are dropped.

## Tests

- The case files in the artifact (pglib-opf v23.07) are byte-identical to the two files fetched from the pinned commit, so nothing changes numerically.
- `NLPTest.runtests()` on the CPU backend: 601/601, identical to the count before the change, with no download step.
- Cold-depot check: with an empty `JULIA_DEPOT_PATH`, the first call to `ExaPowerIO.get_path(:pglib)` fetches and unpacks the artifact, so a fresh runner resolves it correctly.

One thing to note: the artifact is the whole pglib-opf repository, ~350 MB unpacked, for the two case files the tests use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
