### PR TITLE
Rewrite the README overview from the paper; drop the benchmark figure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ Because the pattern and its data travel separately, the repetitive structure is 
 
 This is a deliberate trade relative to general algebraic modeling tools such as [JuMP](https://github.com/jump-dev/JuMP.jl) or [AMPL](https://ampl.com/): ExaModels.jl asks for the model equations in the structured iterator form above, and in exchange preserves the parallelizable structure end to end. Paired with a GPU-capable solver such as [MadNLP.jl](https://github.com/MadNLP/MadNLP.jl), the entire solution pipeline (model evaluation, derivatives, and the optimization itself) runs on the GPU.
 
+## Ahead-of-time compilation: ExaModelsC and JuliaC
+
+Because the model, including its specialized derivative kernels, is fully expressible in Julia's type system, ExaModels.jl is compatible with ahead-of-time compilation via [JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) (`juliac --trim=safe`). The `ExaModelsC` subpackage in this repository builds on that to compile a model into a **self-contained shared library** exposing a plain C interface:
+
+```julia
+using ExaModels, ExaModelsC
+
+c, N = ExaCore(nargs = Val(1))     # N is a size placeholder, resolved at load time
+@add_var(c, x, N; start = 1.0)
+@add_obj(c, (x[i] - 1)^2 for i in 1:N)
+
+compile_library("@rosen", c, 10)   # installs on the CNLPMODELS_PATH search path
+```
+
+The bundled library carries its own privatized Julia runtime, so Python and C callers need no Julia installation at all. Two companion packages consume the C interface: [CNLPModels.jl](https://github.com/MadNLP/CNLPModels.jl) loads the library back into Julia as an `NLPModels.AbstractNLPModel`, and [cnlpmodels](https://github.com/MadNLP/cnlpmodels-py) does the same for Python over ctypes and numpy. A model compiled from a recipe is instantiated per size at load time, `CNLPModel("@rosen", 1000)`; a model compiled with no placeholders needs nothing but the library path.
+
 ## Citation
 
 If you use ExaModels.jl in your research, please cite:

--- a/README.md
+++ b/README.md
@@ -30,24 +30,9 @@ Because the pattern and its data travel separately, the repetitive structure is 
 - **Coloring-free sparse automatic differentiation.** Sparsity is analyzed once, on the pattern itself rather than on the assembled problem, and first- and second-order derivatives are assembled directly into partially compressed sparse COO storage, with no graph coloring and no runtime sparsity detection.
 - **Native GPU execution.** Every NLP function evaluation reduces to embarrassingly parallel loops over data points, implemented portably with [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl). The same model runs on NVIDIA (CUDA), AMD (ROCm), Intel (oneAPI), and OpenCL devices, on Apple silicon via Metal (in Float32, as Metal provides no double precision), and on multi-threaded CPUs.
 - **Near-constant-time evaluation on GPUs.** Once the device supplies enough parallel threads, evaluation cost is set by the number of patterns rather than the number of data points. In our benchmarks, GPU execution evaluates sparse Hessians 76 times faster than single-threaded CPU evaluation on the largest Lukšan–Vlček instances, 30 times on COPS, and 7.3 times on PGLIB-OPF.
+- **Ahead-of-time compilation with JuliaC and ExaModelsC.** Because the model, including its derivative kernels, is fully encoded in Julia's type system, ExaModels.jl is compatible with [JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) (`juliac --trim=safe`). The `ExaModelsC` subpackage builds on this: `compile_library` turns a model into a self-contained shared library with a plain C interface and its own privatized Julia runtime, consumable from Julia via [CNLPModels.jl](https://github.com/MadNLP/CNLPModels.jl) and from Python, with no Julia installation, via [cnlpmodels](https://github.com/MadNLP/cnlpmodels-py).
 
 This is a deliberate trade relative to general algebraic modeling tools such as [JuMP](https://github.com/jump-dev/JuMP.jl) or [AMPL](https://ampl.com/): ExaModels.jl asks for the model equations in the structured iterator form above, and in exchange preserves the parallelizable structure end to end. Paired with a GPU-capable solver such as [MadNLP.jl](https://github.com/MadNLP/MadNLP.jl), the entire solution pipeline (model evaluation, derivatives, and the optimization itself) runs on the GPU.
-
-## Ahead-of-time compilation: ExaModelsC and JuliaC
-
-Because the model, including its specialized derivative kernels, is fully expressible in Julia's type system, ExaModels.jl is compatible with ahead-of-time compilation via [JuliaC.jl](https://github.com/JuliaLang/JuliaC.jl) (`juliac --trim=safe`). The `ExaModelsC` subpackage in this repository builds on that to compile a model into a **self-contained shared library** exposing a plain C interface:
-
-```julia
-using ExaModels, ExaModelsC
-
-c, N = ExaCore(nargs = Val(1))     # N is a size placeholder, resolved at load time
-@add_var(c, x, N; start = 1.0)
-@add_obj(c, (x[i] - 1)^2 for i in 1:N)
-
-compile_library("@rosen", c, 10)   # installs on the CNLPMODELS_PATH search path
-```
-
-The bundled library carries its own privatized Julia runtime, so Python and C callers need no Julia installation at all. Two companion packages consume the C interface: [CNLPModels.jl](https://github.com/MadNLP/CNLPModels.jl) loads the library back into Julia as an `NLPModels.AbstractNLPModel`, and [cnlpmodels](https://github.com/MadNLP/cnlpmodels-py) does the same for Python over ctypes and numpy. A model compiled from a recipe is instantiated per size at load time, `CNLPModel("@rosen", 1000)`; a model compiled with no placeholders needs nothing but the library path.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -6,28 +6,27 @@
 
 | **License** | **Documentation** | **Build Status** | **Coverage** | **Citation** |
 |:-----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
-| [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/exanauts/ExaModels.jl/blob/main/LICENSE) | [![doc](https://img.shields.io/badge/docs-stable-blue.svg)](https://exanauts.github.io/ExaModels.jl/stable) [![doc](https://img.shields.io/badge/docs-dev-blue.svg)](https://exanauts.github.io/ExaModels.jl/dev)  | [![build](https://github.com/exanauts/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/exanauts/ExaModels.jl/actions/workflows/test.yml) | [![codecov](https://codecov.io/gh/exanauts/ExaModels.jl/branch/main/graph/badge.svg?token=8ViJWBWnZt)](https://codecov.io/gh/exanauts/ExaModels.jl) | [![arXiv](https://img.shields.io/badge/arXiv-2307.16830-b31b1b.svg)](https://arxiv.org/abs/2307.16830) |
+| [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/exanauts/ExaModels.jl/blob/main/LICENSE) | [![doc](https://img.shields.io/badge/docs-stable-blue.svg)](https://exanauts.github.io/ExaModels.jl/stable) [![doc](https://img.shields.io/badge/docs-dev-blue.svg)](https://exanauts.github.io/ExaModels.jl/dev)  | [![build](https://github.com/exanauts/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/exanauts/ExaModels.jl/actions/workflows/test.yml) | [![codecov](https://codecov.io/gh/exanauts/ExaModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/exanauts/ExaModels.jl) | [![arXiv](https://img.shields.io/badge/arXiv-2307.16830-b31b1b.svg)](https://arxiv.org/abs/2307.16830) |
 
 ## Overview
-ExaModels.jl employs what we call **[SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) abstraction for [nonlinear programs](https://en.wikipedia.org/wiki/Nonlinear_programming)** (NLPs), which allows for the **preservation of the parallelizable structure** within the model equations, facilitating **efficient, parallel [reverse-mode automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation)** on the **[GPU](https://en.wikipedia.org/wiki/Graphics_processing_unit) accelerators**.
 
-ExaModels.jl is different from other algebraic modeling tools, such as [JuMP](https://github.com/jump-dev/JuMP.jl) or [AMPL](https://ampl.com/), in the following ways:
-- **Modeling Interface**: ExaModels.jl requires users to specify model equations within a restricted environment, ensuring that the model equations are always executable in a SIMD fashion. This structured approach enables ExaModels.jl to maintain the SIMD-compatible format of the model equations, facilitating parallel evaluations of both the model functions and their derivatives. This unique feature distinguishes ExaModels.jl from other algebraic modeling tools.
-- **Performance**: ExaModels.jl compiles (via Julia's compiler) derivative evaluation codes tailored to each computation pattern. Through reverse-mode automatic differentiation using these tailored codes, ExaModels.jl achieves significantly faster derivative evaluation speeds, even when using CPU.
-- **Portability**: ExaModels.jl goes beyond traditional boundaries of
-algebraic modeling systems by **enabling derivative evaluation on GPU
-accelerators**. Implementation of GPU kernels is accomplished using
-the portable programming paradigm offered by
-[KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl).
-With ExaModels.jl, you can run your code on various devices, including
-multi-threaded CPUs, NVIDIA GPUs, AMD GPUs, and Intel GPUs. Note that
-Apple's Metal is currently not supported due to its lack of support
-for double-precision arithmetic.
+Large-scale [nonlinear programs](https://en.wikipedia.org/wiki/Nonlinear_programming) (NLPs) arising in engineering, statistics, and scientific applications almost always have **partially separable, repetitive structure**: the objective and constraints are sums or stacks of scalar terms, and the same algebraic pattern repeats across many data points. What governs solver performance at scale is the speed of the NLP function evaluations — the objective, the constraints, the gradient, the constraint Jacobian, and the Lagrangian Hessian, re-evaluated at every solver iteration — and exploiting the repetitive structure is the key to making them fast.
 
+ExaModels.jl is built around exactly that. It employs a **[SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) abstraction of nonlinear programs**: a model is expressed as a small number of algebraic patterns, each paired with an iterator over the data points at which the pattern is evaluated. A discretized dynamics constraint, for instance, is a single pattern applied at every time step:
 
-## Highlight
-The performance comparison of ExaModels with other algebraic modeling systems for evaluating different NLP functions (obj, con, grad, jac, and hess) are shown below. Note that Hessian computations are the typical bottlenecks.
-![benchmark](https://raw.githubusercontent.com/exanauts/ExaModels.jl/main/docs/src/assets/benchmark.svg)
+```julia
+@add_con(core, h[t] - h[t-1] - 0.5 * dt[1] * (v[t] + v[t-1]) for t = 1:T)
+```
+
+Because the pattern and its data travel separately, the repetitive structure is visible to the system without any structure detection — and the whole pipeline exploits it:
+
+- **Pattern-specialized derivative kernels.** Each algebraic pattern is encoded as a parameterized expression tree in Julia's type system, so the Julia compiler generates a dedicated evaluation and derivative kernel per pattern. Refining a discretization grows the number of data points, never the number of kernels. Even on a single CPU thread, these specialized kernels make derivative evaluation — the sparse Hessian in particular, which is the typical bottleneck — substantially faster than in general-purpose algebraic modeling systems, as shown in the cross-system comparisons of the [accompanying paper](https://arxiv.org/abs/2307.16830).
+- **Coloring-free sparse automatic differentiation.** Sparsity is analyzed once, on the pattern itself rather than on the assembled problem, and first- and second-order derivatives are assembled directly into partially compressed sparse COO storage — no graph coloring and no runtime sparsity detection.
+- **Native GPU execution.** Every NLP function evaluation reduces to embarrassingly parallel loops over data points, implemented portably with [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl). The same model runs on NVIDIA (CUDA), AMD (ROCm), Intel (oneAPI), and OpenCL devices, on Apple silicon via Metal (in Float32 — Metal provides no double precision), and on multi-threaded CPUs.
+- **Constant-time evaluation on GPUs.** With sufficiently many parallel threads, evaluation cost is set by the number of patterns, not the number of data points. On the largest instances of the paper's benchmarks, GPU execution evaluates sparse Hessians 76× faster than single-threaded CPU evaluation on the Lukšan–Vlček problems, 30× on COPS, and 7.3× on PGLIB-OPF.
+
+This is a deliberate trade relative to general algebraic modeling tools such as [JuMP](https://github.com/jump-dev/JuMP.jl) or [AMPL](https://ampl.com/): ExaModels.jl asks for the model equations in the structured iterator form above, and in exchange preserves the parallelizable structure end to end. Paired with a GPU-capable solver such as [MadNLP.jl](https://github.com/MadNLP/MadNLP.jl), it makes the entire NLP solution pipeline — model evaluation, derivatives, and the optimization itself — run on the GPU.
+
 ## Supporting ExaModels.jl
-- Please report issues and feature requests via the [GitHub issue tracker](https://github.com/exanatus/ExaModels.jl/issues).
+- Please report issues and feature requests via the [GitHub issue tracker](https://github.com/exanauts/ExaModels.jl/issues).
 - Questions are welcome at [GitHub discussion forum](https://github.com/exanauts/ExaModels.jl/discussions).

--- a/README.md
+++ b/README.md
@@ -10,22 +10,44 @@
 
 ## Overview
 
-Large-scale [nonlinear programs](https://en.wikipedia.org/wiki/Nonlinear_programming) (NLPs) arising in engineering, statistics, and scientific applications almost always have **partially separable, repetitive structure**: the objective and constraints are sums or stacks of scalar terms, and the same algebraic pattern repeats across many data points. What governs solver performance at scale is the speed of the NLP function evaluations — the objective, the constraints, the gradient, the constraint Jacobian, and the Lagrangian Hessian, re-evaluated at every solver iteration — and exploiting the repetitive structure is the key to making them fast.
+Large-scale [nonlinear programs](https://en.wikipedia.org/wiki/Nonlinear_programming) (NLPs) arising in engineering, statistics, and scientific applications almost always have **partially separable, repetitive structure**: the objective and constraints are sums or stacks of scalar terms, and the same algebraic pattern repeats across many data points. An NLP solver re-evaluates the model functions (the objective, the constraints, the gradient, the constraint Jacobian, and the Lagrangian Hessian) at every iteration, so the cost of these evaluations can take up a substantial part of the total solution time. Exploiting the repetitive structure is the key to making them fast.
 
-ExaModels.jl is built around exactly that. It employs a **[SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) abstraction of nonlinear programs**: a model is expressed as a small number of algebraic patterns, each paired with an iterator over the data points at which the pattern is evaluated. A discretized dynamics constraint, for instance, is a single pattern applied at every time step:
+ExaModels.jl is built around exactly that. It employs a **[SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) abstraction of nonlinear programs**: a model is expressed as a small number of algebraic patterns, each paired with an iterator over the data points at which the pattern is evaluated. The velocity dynamics of the Goddard rocket problem, for instance, is a single pattern applied at every time step:
 
 ```julia
-@add_con(core, h[t] - h[t-1] - 0.5 * dt[1] * (v[t] + v[t-1]) for t = 1:T)
+@add_con(core, vel,
+    -v[i] + v[i-1] + 0.5 * dt[1] * (
+        (tau[i] - D_c * v[i]^2 * exp(-h_c * (h[i] - h_0) / h_0)
+            - m[i] * g_0 * (h_0 / h[i])^2) / m[i]
+        + (tau[i-1] - D_c * v[i-1]^2 * exp(-h_c * (h[i-1] - h_0) / h_0)
+            - m[i-1] * g_0 * (h_0 / h[i-1])^2) / m[i-1])
+    for i = 1:nh)
 ```
 
-Because the pattern and its data travel separately, the repetitive structure is visible to the system without any structure detection — and the whole pipeline exploits it:
+Because the pattern and its data travel separately, the repetitive structure is visible to the system without any structure detection, and the whole pipeline exploits it:
 
-- **Pattern-specialized derivative kernels.** Each algebraic pattern is encoded as a parameterized expression tree in Julia's type system, so the Julia compiler generates a dedicated evaluation and derivative kernel per pattern. Refining a discretization grows the number of data points, never the number of kernels. Even on a single CPU thread, these specialized kernels make derivative evaluation — the sparse Hessian in particular, which is the typical bottleneck — substantially faster than in general-purpose algebraic modeling systems, as shown in the cross-system comparisons of the [accompanying paper](https://arxiv.org/abs/2307.16830).
-- **Coloring-free sparse automatic differentiation.** Sparsity is analyzed once, on the pattern itself rather than on the assembled problem, and first- and second-order derivatives are assembled directly into partially compressed sparse COO storage — no graph coloring and no runtime sparsity detection.
-- **Native GPU execution.** Every NLP function evaluation reduces to embarrassingly parallel loops over data points, implemented portably with [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl). The same model runs on NVIDIA (CUDA), AMD (ROCm), Intel (oneAPI), and OpenCL devices, on Apple silicon via Metal (in Float32 — Metal provides no double precision), and on multi-threaded CPUs.
-- **Constant-time evaluation on GPUs.** With sufficiently many parallel threads, evaluation cost is set by the number of patterns, not the number of data points. On the largest instances of the paper's benchmarks, GPU execution evaluates sparse Hessians 76× faster than single-threaded CPU evaluation on the Lukšan–Vlček problems, 30× on COPS, and 7.3× on PGLIB-OPF.
+- **Pattern-specialized derivative kernels.** Each algebraic pattern is encoded as a parameterized expression tree in Julia's type system, so the Julia compiler generates a dedicated evaluation and derivative kernel per pattern. Refining a discretization grows the number of data points, never the number of kernels. Even on a single CPU thread, these specialized kernels make derivative evaluation (the sparse Hessian in particular, which is the typical bottleneck) substantially faster than in general-purpose modeling and AD frameworks in our cross-system benchmarks.
+- **Coloring-free sparse automatic differentiation.** Sparsity is analyzed once, on the pattern itself rather than on the assembled problem, and first- and second-order derivatives are assembled directly into partially compressed sparse COO storage, with no graph coloring and no runtime sparsity detection.
+- **Native GPU execution.** Every NLP function evaluation reduces to embarrassingly parallel loops over data points, implemented portably with [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl). The same model runs on NVIDIA (CUDA), AMD (ROCm), Intel (oneAPI), and OpenCL devices, on Apple silicon via Metal (in Float32, as Metal provides no double precision), and on multi-threaded CPUs.
+- **Near-constant-time evaluation on GPUs.** Once the device supplies enough parallel threads, evaluation cost is set by the number of patterns rather than the number of data points. In our benchmarks, GPU execution evaluates sparse Hessians 76 times faster than single-threaded CPU evaluation on the largest Lukšan–Vlček instances, 30 times on COPS, and 7.3 times on PGLIB-OPF.
 
-This is a deliberate trade relative to general algebraic modeling tools such as [JuMP](https://github.com/jump-dev/JuMP.jl) or [AMPL](https://ampl.com/): ExaModels.jl asks for the model equations in the structured iterator form above, and in exchange preserves the parallelizable structure end to end. Paired with a GPU-capable solver such as [MadNLP.jl](https://github.com/MadNLP/MadNLP.jl), it makes the entire NLP solution pipeline — model evaluation, derivatives, and the optimization itself — run on the GPU.
+This is a deliberate trade relative to general algebraic modeling tools such as [JuMP](https://github.com/jump-dev/JuMP.jl) or [AMPL](https://ampl.com/): ExaModels.jl asks for the model equations in the structured iterator form above, and in exchange preserves the parallelizable structure end to end. Paired with a GPU-capable solver such as [MadNLP.jl](https://github.com/MadNLP/MadNLP.jl), the entire solution pipeline (model evaluation, derivatives, and the optimization itself) runs on the GPU.
+
+## Citation
+
+If you use ExaModels.jl in your research, please cite:
+
+```bibtex
+@article{shin2024accelerating,
+  title   = {Accelerating optimal power flow with {GPUs}: {SIMD} abstraction of nonlinear programs and condensed-space interior-point methods},
+  author  = {Shin, Sungho and Anitescu, Mihai and Pacaud, Fran\c{c}ois},
+  journal = {Electric Power Systems Research},
+  volume  = {236},
+  pages   = {110651},
+  year    = {2024},
+  doi     = {10.1016/j.epsr.2024.110651}
+}
+```
 
 ## Supporting ExaModels.jl
 - Please report issues and feature requests via the [GitHub issue tracker](https://github.com/exanauts/ExaModels.jl/issues).


### PR DESCRIPTION
The overview now follows the paper's storyline: partially separable, repetitive structure → SIMD abstraction (a small number of algebraic patterns × many data points, with the paper's dynamics-constraint example) → pattern-specialized derivative kernels from the type-encoded expression tree → coloring-free sparse AD assembled into partially compressed COO → portable GPU execution via KernelAbstractions → $O(1)$ evaluation once the device supplies enough threads, with the paper's measured sparse-Hessian speedups on the largest benchmark instances (76× Lukšan–Vlček, 30× COPS, 7.3× PGLIB-OPF, GPU vs single-threaded CPU). The Highlight section and the benchmark figure are removed.

Three incidental fixes: the Metal paragraph was stale (the Metal extension exists and runs in CI — the actual caveat is Float32 promotion), the codecov badge is pinned to `branch/main` without the token parameter, and the `exanatus` typo in the issue-tracker link is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)