### PR TITLE
Update repository URLs after the transfer to madsuite-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | **License** | **Documentation** | **Build Status** | **Coverage** | **Citation** |
 |:-----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
-| [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/exanauts/ExaModels.jl/blob/main/LICENSE) | [![doc](https://img.shields.io/badge/docs-stable-blue.svg)](https://exanauts.github.io/ExaModels.jl/stable) [![doc](https://img.shields.io/badge/docs-dev-blue.svg)](https://exanauts.github.io/ExaModels.jl/dev)  | [![build](https://github.com/exanauts/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/exanauts/ExaModels.jl/actions/workflows/test.yml) | [![codecov](https://codecov.io/gh/exanauts/ExaModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/exanauts/ExaModels.jl) | [![arXiv](https://img.shields.io/badge/arXiv-2307.16830-b31b1b.svg)](https://arxiv.org/abs/2307.16830) |
+| [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/madsuite-org/ExaModels.jl/blob/main/LICENSE) | [![doc](https://img.shields.io/badge/docs-stable-blue.svg)](https://madsuite-org.github.io/ExaModels.jl/stable) [![doc](https://img.shields.io/badge/docs-dev-blue.svg)](https://madsuite-org.github.io/ExaModels.jl/dev)  | [![build](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml) | [![codecov](https://codecov.io/gh/madsuite-org/ExaModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/madsuite-org/ExaModels.jl) | [![arXiv](https://img.shields.io/badge/arXiv-2307.16830-b31b1b.svg)](https://arxiv.org/abs/2307.16830) |
 
 ## Overview
 
@@ -51,5 +51,5 @@ If you use ExaModels.jl in your research, please cite:
 ```
 
 ## Supporting ExaModels.jl
-- Please report issues and feature requests via the [GitHub issue tracker](https://github.com/exanauts/ExaModels.jl/issues).
-- Questions are welcome at [GitHub discussion forum](https://github.com/exanauts/ExaModels.jl/discussions).
+- Please report issues and feature requests via the [GitHub issue tracker](https://github.com/madsuite-org/ExaModels.jl/issues).
+- Questions are welcome at [GitHub discussion forum](https://github.com/madsuite-org/ExaModels.jl/discussions).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -86,4 +86,4 @@ makedocs(
 )
 
 
-deploydocs(repo = "github.com/exanauts/ExaModels.jl.git"; push_preview = true)
+deploydocs(repo = "github.com/madsuite-org/ExaModels.jl.git"; push_preview = true)

--- a/src/ExaModels.jl
+++ b/src/ExaModels.jl
@@ -22,7 +22,7 @@ Operations involving `Constant{T}` are simplified at model-construction time:
 `specialization.jl`).  Combined `Constant OP Constant` expressions are folded
 to a new `Constant` via the rules in `register.jl`.
 
-For more information, please visit https://github.com/exanauts/ExaModels.jl
+For more information, please visit https://github.com/madsuite-org/ExaModels.jl
 """
 module ExaModels
 


### PR DESCRIPTION
README badges and links, the Documenter deploy target, and the module docstring now point at madsuite-org/ExaModels.jl. GitHub Pages does not redirect across owners, so the docs-badge links (exanauts.github.io/ExaModels.jl) were the ones that had actually broken; they now point at madsuite-org.github.io/ExaModels.jl. The codecov badge slug is updated to the new owner as well.

This PR's CI run is also the first real post-transfer test that the self-hosted runners still pick up jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)