### PR TITLE
ExaModelsC: carry a recipe's own package into the generated app

### DIFF
--- a/ExaModelsC/Project.toml
+++ b/ExaModelsC/Project.toml
@@ -8,6 +8,7 @@ ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
 JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
 ExaModels = {path = ".."}

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -59,6 +59,7 @@ import ExaModels
 import JuliaC
 import Random
 import Serialization
+import TOML
 
 export compile_library
 
@@ -342,6 +343,97 @@ function _check_prefix(prefix::AbstractString)
     return prefix
 end
 
+# ── The packages a core's own types come from ─────────────────────────────────
+#
+# A recipe defers more than sizes.  A starting point that varies with the index,
+# or the set a generator runs over when that set is computed from the size, is a
+# function the MODELLING library wrote, and it travels inside the serialized core
+# as a type that library owns.  Nothing is wrong with that — it is data, it
+# serializes, and `instantiate` runs it — but the generated app is a different
+# process, and it has to be able to name those types again.
+#
+# `Serialization` resolves a type's module through `Base.PkgId`, and only among
+# modules that are LOADED.  So the app has to do two things, and doing one is
+# not enough: depend on the package, and `import` it before deserializing.  With
+# the dependency present but no import, the deserialize fails with exactly the
+# same `KeyError` as with no dependency at all — which is why this is worth
+# stating rather than leaving to whoever reads the generated `Project.toml`.
+#
+# An EXTENSION is where a modelling library naturally writes these functions,
+# since they are the ones that use ExaModels.  An extension cannot be depended
+# on directly, so it is resolved to its parent package: the app imports the
+# parent, ExaModels is already imported, and Julia loads the extension itself.
+
+struct _Pkg
+    name::String
+    uuid::Base.UUID
+    dir::String
+end
+
+function _collect_modules!(mods::Set{Module}, seen::Base.IdSet{Any}, @nospecialize(T))
+    T in seen && return mods
+    push!(seen, T)
+    if T isa UnionAll
+        return _collect_modules!(mods, seen, T.body)
+    elseif T isa Union
+        _collect_modules!(mods, seen, T.a)
+        return _collect_modules!(mods, seen, T.b)
+    elseif T isa DataType
+        push!(mods, parentmodule(T))
+        for p in T.parameters
+            p isa Type && _collect_modules!(mods, seen, p)
+        end
+    end
+    return mods
+end
+
+# The package a module belongs to, or `nothing` for Base/Core/ExaModels, for
+# `Main`, and for anything else with no `Project.toml` behind it.  A module
+# whose entry point is not `<dir>/src/<Name>.jl` is an extension: its `pkgdir`
+# is already the parent's, so the parent's name and uuid are read from there.
+function _owning_package(m::Module)
+    (m === Base || m === Core || m === ExaModels) && return nothing
+    Base.moduleroot(m) === m || return nothing
+    id = Base.PkgId(m)
+    id.uuid === nothing && return nothing              # Main, and other non-packages
+    dir = pkgdir(m)
+    dir === nothing && return nothing
+    path = Base.locate_package(id)
+    if path !== nothing &&
+       normpath(path) == normpath(joinpath(dir, "src", id.name * ".jl"))
+        return _Pkg(id.name, id.uuid, abspath(dir))
+    end
+    # An extension — take the package it belongs to.
+    for base in ("JuliaProject.toml", "Project.toml")
+        proj = joinpath(dir, base)
+        isfile(proj) || continue
+        toml = TOML.parsefile(proj)
+        name = get(toml, "name", nothing)
+        uuid = get(toml, "uuid", nothing)
+        (name isa String && uuid isa String) || continue
+        return _Pkg(name, Base.UUID(uuid), abspath(dir))
+    end
+    return nothing
+end
+
+"""
+    _core_packages(core) -> Vector{_Pkg}
+
+Every package, other than ExaModels itself, that owns a type inside `core`.
+These become dependencies of the generated app *and* imports in its module, so
+that the serialized core can be read back there.
+"""
+function _core_packages(core)
+    mods = _collect_modules!(Set{Module}(), Base.IdSet{Any}(), typeof(core))
+    pkgs = _Pkg[]
+    for m in sort!(collect(mods); by = string)
+        p = _owning_package(m)
+        p === nothing && continue
+        any(q -> q.uuid == p.uuid, pkgs) || push!(pkgs, p)
+    end
+    return pkgs
+end
+
 # ── Generating the app package ────────────────────────────────────────────────
 
 function _generate_app(core, arg, field, prefix::AbstractString)
@@ -361,12 +453,22 @@ function _generate_app(core, arg, field, prefix::AbstractString)
     # instantiating, which silently breaks relative `path =` entries: they would
     # resolve against the copy's parent. Absolute from the start.
     exadir = abspath(joinpath(dirname(dirname(pathof(ExaModels)))))
-    write(joinpath(appdir, "Project.toml"), _project_toml(modname, exadir))
-    write(joinpath(srcdir, modname * ".jl"), _module_source(modname, prefix, field))
+    pkgs = _core_packages(core)
+    write(joinpath(appdir, "Project.toml"), _project_toml(modname, exadir, pkgs))
+    write(
+        joinpath(srcdir, modname * ".jl"),
+        _module_source(modname, prefix, field, pkgs),
+    )
     return appdir
 end
 
-function _project_toml(modname::AbstractString, exadir::AbstractString)
+_toml_path(dir::AbstractString) = replace(dir, '\\' => '/')
+
+function _project_toml(modname::AbstractString, exadir::AbstractString, pkgs = _Pkg[])
+    deps = join(("""$(p.name) = "$(p.uuid)"\n""" for p in pkgs))
+    # A path source rather than a version bound: the app must compile the same
+    # code that produced the core, not merely something compatible with it.
+    sources = join(("""$(p.name) = {path = "$(_toml_path(p.dir))"}\n""" for p in pkgs))
     return """
     name = "$modname"
     uuid = "$_GEN_UUID"
@@ -375,10 +477,10 @@ function _project_toml(modname::AbstractString, exadir::AbstractString)
     [deps]
     ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
     Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
+    $deps
     [sources]
-    ExaModels = {path = "$(replace(exadir, '\\' => '/'))"}
-    """
+    ExaModels = {path = "$(_toml_path(exadir))"}
+    $sources"""
 end
 
 # A fixed model: the core carries no placeholders, so `<prefix>_new(n)`
@@ -401,14 +503,18 @@ _arg_expr(::FixedModel) = "nothing"
 _nargs_value(::FixedModel) = 0
 _nargs_value(::Union{Nothing, Symbol}) = 1
 
-function _module_source(modname::AbstractString, p::AbstractString, field)
+function _module_source(modname::AbstractString, p::AbstractString, field, pkgs = _Pkg[])
     argexpr = _arg_expr(field)
+    # Imported for their side effect on `Serialization`: a module has to be
+    # loaded before a type it owns can be resolved by `PkgId`, and the
+    # deserialize below is what needs them.  A dependency alone is not enough.
+    imports = join(("import $(p.name)\n" for p in pkgs))
     return """
     module $modname
 
     import ExaModels
     import Serialization
-
+    $imports
     # Deserialized at precompile time, so the core is baked into the package
     # image and no model-building code enters the compiled call graph.
     const CORE = Serialization.deserialize(joinpath(@__DIR__, "core.jls"))

--- a/ExaModelsC/test/Project.toml
+++ b/ExaModelsC/test/Project.toml
@@ -4,11 +4,16 @@ ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
 ExaModelsC = "3d1e9a26-5b74-4f0c-9a2b-7c8f4e11d3a7"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+RecipeKernels = "5c1e4a77-3b0d-4f92-9c8a-1e7d6b0f3a24"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 ExaModels = {path = "../.."}
 ExaModelsC = {path = ".."}
+# A stand-in modelling library, so a recipe can be built that owns a type no
+# other package does — see the "a recipe's own package" testset.
+RecipeKernels = {path = "fixtures/RecipeKernels"}
 # CNLPModels is unregistered, so it is resolved straight from its repository.
 # The Python consumer (https://github.com/MadNLP/cnlpmodels-py) is not a Julia
 # dependency at all — the test finds it through CNLPMODELS_PY and skips when it

--- a/ExaModelsC/test/fixtures/RecipeKernels/Project.toml
+++ b/ExaModelsC/test/fixtures/RecipeKernels/Project.toml
@@ -1,0 +1,12 @@
+name = "RecipeKernels"
+uuid = "5c1e4a77-3b0d-4f92-9c8a-1e7d6b0f3a24"
+version = "0.1.0"
+
+# An extension is where a modelling library naturally writes its recipe pieces —
+# they are the parts that use ExaModels.  A type owned by an extension has to
+# resolve to this package, since an extension cannot itself be depended on.
+[weakdeps]
+ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
+
+[extensions]
+RecipeKernelsExaModels = "ExaModels"

--- a/ExaModelsC/test/fixtures/RecipeKernels/ext/RecipeKernelsExaModels.jl
+++ b/ExaModelsC/test/fixtures/RecipeKernels/ext/RecipeKernelsExaModels.jl
@@ -1,0 +1,10 @@
+module RecipeKernelsExaModels
+
+import ExaModels
+import RecipeKernels
+
+"A start kernel owned by the EXTENSION rather than by the package, so a core
+built with it names a module that cannot be a dependency of anything."
+@inline ramp(i) = 0.25 * i
+
+end # module

--- a/ExaModelsC/test/fixtures/RecipeKernels/src/RecipeKernels.jl
+++ b/ExaModelsC/test/fixtures/RecipeKernels/src/RecipeKernels.jl
@@ -1,0 +1,28 @@
+"""
+    RecipeKernels
+
+A stand-in for a modelling library, in the one respect that matters here: it
+owns a function that ends up *inside* a recipe rather than beside it.
+
+A starting point that varies with the index cannot be a number in the core, and
+the size it runs over is not known while the structure is written — so it is
+deferred, and the deferred thing is a function this package wrote.  The core
+that comes out therefore names a `RecipeKernels` type, and a process that
+cannot load `RecipeKernels` cannot read that core back.
+
+The functions are deliberately named rather than anonymous: a `Base.Generator`
+over `alternating` carries `typeof(alternating)`, which is stable across
+recompiles, whereas a closure carries a gensym that is not.
+"""
+module RecipeKernels
+
+export alternating, offsets
+
+"Alternating starting point — the shape a per-index start generator takes."
+@inline alternating(i) = isodd(i) ? -1.2 : 1.0
+
+"An index set computed from the size: a comprehension, so it has no symbolic
+form and has to run once the size is known."
+offsets(n) = [2 * div(i - 1, 2) for i in 1:2:max(n - 2, 0)]
+
+end # module

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -2,6 +2,8 @@ module ExaModelsCTest
 
 using Test
 using ExaModels, ExaModelsC
+import Pkg
+import RecipeKernels
 import CNLPModels
 import NLPModels
 import NLPModelsIpopt
@@ -38,6 +40,85 @@ function runtests()
             # And a prefix that is not a C identifier is caught before juliac.
             @test_throws ArgumentError compile_library(OUT, c, 4; prefix = "lib-a")
             @test_throws ArgumentError compile_library(OUT, c, 4; prefix = "2fast")
+        end
+
+        @testset "a recipe's own package travels into the generated app" begin
+            # A modelling library's own function inside the core is the ordinary
+            # case, not an exotic one: a per-index start and a size-dependent
+            # index set both have to be deferred, and what gets deferred is that
+            # library's code.  The core then names a `RecipeKernels` type.
+            c, N = ExaCore(nargs = Val(1))
+            @add_var(c, x, N; start = Base.Generator(RecipeKernels.alternating, 1:N))
+            @add_obj(c, (x[i] - 2.0)^2 for i in 1:N)
+            @add_con(c, x[l+1] + x[l+2] for l in ExaModels.ArgNode1(RecipeKernels.offsets, N))
+
+            pkgs = ExaModelsC._core_packages(ExaModelsC._concretize(c))
+            @test length(pkgs) == 1
+            @test only(pkgs).name == "RecipeKernels"
+            @test isdir(only(pkgs).dir)
+
+            # A core with nothing but ExaModels in it must not drag anything in:
+            # the generated project has to stay exactly as it was for every model
+            # that does not need this.
+            plain, M = ExaCore(nargs = Val(1))
+            @add_var(plain, z, M; start = 1.0)
+            @add_obj(plain, (z[i] - 2.0)^2 for i in 1:M)
+            @test isempty(ExaModelsC._core_packages(ExaModelsC._concretize(plain)))
+
+            # Both halves are needed and neither alone is enough: a dependency
+            # the app never imports resolves no better than one it never had, so
+            # the generated files are checked for the dependency AND the import.
+            appdir = ExaModelsC._generate_app(
+                ExaModelsC._concretize(c), 8, nothing, "rk",
+            )
+            proj = read(joinpath(appdir, "Project.toml"), String)
+            src = read(joinpath(appdir, "src", "ExaLib_rk.jl"), String)
+            @test occursin("RecipeKernels = \"5c1e4a77", proj)
+            @test occursin("RecipeKernels = {path =", proj)
+            @test occursin("import RecipeKernels", src)
+
+            # And the property those two exist for: a *different* process, whose
+            # only knowledge of RecipeKernels is what the generated project says,
+            # can read the core back and build a model from it.  This is the step
+            # that failed before, with `KeyError: PkgId(... "RecipeKernels")`.
+            probe = joinpath(appdir, "probe.jl")
+            answer = joinpath(appdir, "answer.txt")
+            write(probe, """
+                import Pkg
+                Pkg.instantiate(; io = devnull)
+                import ExaModels, Serialization, RecipeKernels
+                core = Serialization.deserialize(joinpath(@__DIR__, "src", "core.jls"))
+                m = ExaModels.ExaModel(core, 12; check = Val(false))
+                write(
+                    joinpath(@__DIR__, "answer.txt"),
+                    string(m.meta.nvar, ",", m.meta.ncon, ",", m.meta.x0[1], ",", m.meta.x0[2]),
+                )
+                """)
+            # Keep the child's output: without it a failure here reads as a bare
+            # `false`, and the whole point of this assertion is the reason.
+            log = IOBuffer()
+            ran = success(pipeline(
+                `$(Base.julia_cmd()) --startup-file=no --project=$appdir $probe`;
+                stdout = log, stderr = log,
+            ))
+            ran || @error "generated app failed to load its core" output =
+                String(take!(log))
+            @test ran
+            @test isfile(answer) && read(answer, String) == "12,5,-1.2,1.0"
+
+            # An extension is the natural home for a recipe's ExaModels-facing
+            # parts, and a type it owns cannot be depended on by name — there is
+            # no `RecipeKernelsExaModels` to add to a project.  It has to resolve
+            # to the package that carries it, which the app then imports;
+            # ExaModels is already imported, so Julia loads the extension itself.
+            ext = Base.get_extension(RecipeKernels, :RecipeKernelsExaModels)
+            @test ext !== nothing
+            e, K = ExaCore(nargs = Val(1))
+            @add_var(e, w, K; start = Base.Generator(ext.ramp, 1:K))
+            @add_obj(e, (w[i] - 1.0)^2 for i in 1:K)
+            epkgs = ExaModelsC._core_packages(ExaModelsC._concretize(e))
+            @test length(epkgs) == 1
+            @test only(epkgs).name == "RecipeKernels"       # the parent, not the ext
         end
 
         @testset "out is @name on the search path, or a literal path" begin


### PR DESCRIPTION
## The problem

`compile_library` serializes the core into a generated app package, which juliac
then compiles. That app declared exactly two dependencies — ExaModels and
Serialization — which is enough only while every type in the core belongs to
ExaModels.

A recipe defers more than sizes. A starting point that varies with the index, or
the set a generator runs over when that set is computed from the size, is a
function written outside ExaModels, and it travels inside the serialized core as
a type that other package owns. The app, a different process, could not name
those types again:

```
KeyError: key Base.PkgId(UUID("dc0393f0-…"), "LuksanVlcekBenchmark") not found
```

## Two things are needed, and one alone does nothing

`Serialization` resolves a type's module through `PkgId`, and only among modules
that are **loaded**. Measured, all three cases:

| generated app has | result |
|---|---|
| no dependency on the package | `KeyError` |
| the dependency, no `import` | **the same `KeyError`** |
| the dependency **and** `import` | deserializes and instantiates |

So the project file and the module source have to change together, and the
generated module now carries the imports rather than leaving them implied.

## What the walk is for

`_core_packages` walks the core's type parameters and maps each owning module to
its package. Deliberately a walk rather than a lookup of "the modelling
package", because the owner is frequently neither ExaModels nor the library that
built the model — and it is not predictable from whether the core is a recipe.
Two libraries, measured, come out opposite ways:

```
LuksanVlcekBenchmark   recipe -> ["LuksanVlcekBenchmark"]   fixed -> []
ExaModelsPower/OPF     recipe -> []                         fixed -> ["ExaPowerIO"]
```

LVB defers a start generator and index sets, so its own functions sit in the
recipe and eager construction materialises them away. A fixed AC OPF core
materialises `Vector{ExaPowerIO.BusData{Float64}}` — a *third* package, the
parser — into itself, and the model-building package appears in neither form.

An extension is where a modelling library naturally writes these functions,
since they are the ones that use ExaModels. An extension cannot be depended on
by name, so it resolves to its parent package; ExaModels is already imported, so
Julia loads the extension itself. Sources are path entries rather than version
bounds: the app must compile the code that produced the core, not merely
something compatible with it.

## Not a change for models that do not need it

A core holding only ExaModels types yields an empty list and the generated files
come out as before. There is an explicit assertion for that.

## Testing

A fixture package, `ExaModelsC/test/fixtures/RecipeKernels`, stands in for a
modelling library in both forms — a kernel in the package and one in its
extension. The assertion that matters is the last one: a **separate process**,
knowing the fixture only through the generated project, reads the core back and
builds a model from it. Against unpatched `main` in a clean worktree that step
fails with the `KeyError` above.

- Full `ExaModelsC` suite: **85 passed, 0 failed** (2m05s), juliac leg included.
  Confirmed the new testset is genuinely inside that count by mutating one
  assertion: the breakdown reads `84 1 85` with `11 1 12` in the new testset.
- Downstream: all of LuksanVlcekBenchmark's problems compile to a shared library
  through this path and match their in-Julia models exactly at sizes the library
  never saw at compile time.

One new stdlib dependency, `TOML`, for reading the parent's `Project.toml` in the
extension branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
