### PR TITLE
ExaModelsC: make unbundled output the default

### DIFF
--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -79,12 +79,14 @@ Compile `core` into a shared library under `out`, and return the path to it.
 `bundle = true` (the default) emits a directory carrying the library together
 with a **privatized** copy of the Julia runtime — around 80 MB, needing no Julia
 on the consumer's side.  `bundle = false` emits a single ~2 MB library linked
-against the Julia installation it was built with.
+against the Julia installation it was built with, which the consumer's machine
+must then have (same version, found through the library's recorded rpath or
+provided by the consumer).
 
 | consumer | `bundle = true` | `bundle = false` |
 |:---------|:----------------|:-----------------|
 | Python (`cnlpmodels`), C | works | works |
-| **Julia (`CNLPModels.jl`)** | works | **aborts on the first call** |
+| Julia (`CNLPModels.jl`) | works | works on Linux; refused elsewhere |
 
 !!! warning "Windows"
     `juliac` implements runtime privatization for Linux and macOS only — on
@@ -105,11 +107,16 @@ runtime's* thread-local storage, so a privatized runtime — a distinct one, who
 against the installed Julia instead, or bundling without privatizing, both
 reproduce the abort; measured, not assumed.
 
-Fixing that properly means skipping the adoption when the thread is already a
-Julia thread, which is upstream in juliac's generated preamble.  Until then the
-privatized bundle is the only form `CNLPModels.jl` can load, which is why it is
-the default; pass `bundle = false` for a Python or C caller that would rather
-have 2 MB than 80.
+The two forms therefore differ only in *when* privatization happens.  A bundle
+carries its privatized runtime with it; an unbundled library gets one at load
+time — on Linux, `CNLPModels.load` detects the standard `libjulia` soname in
+its NEEDED entries and provisions a salted copy of the consumer's *installed*
+runtime (the same transformation JuliaC's bundler applies, replayed in
+scratch).  Python and C callers load either form as-is: there the calling
+thread is genuinely foreign and the library's own runtime initializes on the
+first call.  On macOS the load-time half is not implemented, so
+`CNLPModels.jl` needs the bundle there; it refuses the unbundled form with an
+explanation rather than aborting.
 
 ## Where it goes
 

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -1,7 +1,7 @@
 """
     ExaModelsC
 
-Compile an [`ExaModels.ExaCore`](@ref) into a self-contained shared library that
+Compile an [`ExaModels.ExaCore`](@ref) into a shared library that
 exposes the model through the plain C interface consumed by
 [CNLPModels.jl](https://github.com/MadNLP/CNLPModels.jl) (and its Python twin
 `cnlpmodels`).
@@ -39,13 +39,13 @@ which is part of ExaModels:
 
 ```julia
 using CNLPModels, NLPModelsIpopt
-lib = CNLPModels.load("/opt/models/rosen/lib/librosen.so")
+lib = CNLPModels.load("/opt/models/rosen/librosen.so")
 ipopt(CNLPModel(lib, 1000; prefix = "rosen"))
 ```
 
 ```python
 import cnlpmodels
-lib = cnlpmodels.load("/opt/models/rosen/lib/librosen.so")
+lib = cnlpmodels.load("/opt/models/rosen/librosen.so")
 m = cnlpmodels.CModel(lib, 1000, prefix="rosen")
 ```
 
@@ -69,24 +69,24 @@ const _GEN_UUID = "b41c7e02-9f3d-4a58-8e6c-2d0f5a7c9b13"
 
 """
     compile_library(out, core, args...; prefix = basename(out), trim = "safe",
-                    bundle = true, verbose = false)
+                    bundle = false, verbose = false)
         -> (; libpath, outdir, prefix)
 
 Compile `core` into a shared library under `out`, and return the path to it.
 
 ## `bundle`
 
-`bundle = true` (the default) emits a directory carrying the library together
-with a **privatized** copy of the Julia runtime — around 80 MB, needing no Julia
-on the consumer's side.  `bundle = false` emits a single ~2 MB library linked
-against the Julia installation it was built with, which the consumer's machine
-must then have (same version, found through the library's recorded rpath or
-provided by the consumer).
+`bundle = false` (the default) emits a single ~2 MB library linked against the
+Julia installation it was built with, which the consumer's machine must then
+have (same version, found through the library's recorded rpath or provided by
+the consumer).  `bundle = true` emits a directory carrying the library together
+with a **privatized** copy of the Julia runtime — around 80 MB, needing no
+Julia on the consumer's side.
 
-| consumer | `bundle = true` | `bundle = false` |
-|:---------|:----------------|:-----------------|
+| consumer | `bundle = false` (default) | `bundle = true` |
+|:---------|:---------------------------|:----------------|
 | Python (`cnlpmodels`), C | works | works |
-| Julia (`CNLPModels.jl`) | works | works on Linux; refused elsewhere |
+| Julia (`CNLPModels.jl`) | works on Linux; refused elsewhere | works |
 
 !!! warning "Windows"
     `juliac` implements runtime privatization for Linux and macOS only — on
@@ -168,7 +168,7 @@ function compile_library(
     args...;
     prefix::AbstractString = _default_out_prefix(out),
     trim::AbstractString = "safe",
-    bundle::Bool = true,
+    bundle::Bool = false,
     verbose::Bool = false,
 )
     _check_prefix(prefix)

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -170,12 +170,9 @@ function runtests()
             @test m2.meta.nvar == n
         end
 
-        @testset "bundle = false is a single file, for Python and C callers" begin
+        @testset "bundle = false is a single file, loadable everywhere" begin
             # One ~2 MB library rather than an 80 MB directory, linked against
-            # the installed Julia.  This is the form to hand a Python or C
-            # caller; it cannot be loaded from Julia — see `compile_library`'s
-            # docstring for why — so it is checked structurally here and the
-            # Python leg below exercises the behaviour.
+            # the installed Julia.
             u = compile_library(joinpath(OUT, "flat"), build(), 4; bundle = false)
             @test isfile(u.libpath)
             @test u.libpath == joinpath(
@@ -183,6 +180,33 @@ function runtests()
             @test !isdir(joinpath(u.outdir, "lib", "julia"))     # not a bundle
             @test filesize(u.libpath) < 20_000_000
             @test filesize(u.libpath) < filesize(r.libpath) * 10 # far smaller than bundled
+
+            if Sys.islinux()
+                # In-process consumption: CNLPModels detects the standard
+                # libjulia NEEDED and provisions a load-time private runtime
+                # (loading this library as-is would abort the process, so
+                # this block passing IS the mechanism working). The bundled
+                # `rosen` runtime above is already resident: the two must
+                # coexist.
+                ulib = CNLPModels.load(u.libpath)
+                N = 17
+                um = CNLPModels.CNLPModel(ulib, N; prefix = u.prefix)
+                ref = ExaModel(build(), N)
+                x = collect(range(0.5, 3.0; length = N))
+                @test um.meta.nvar == ref.meta.nvar == N
+                @test NLPModels.obj(um, x) ≈ NLPModels.obj(ref, x)
+                @test NLPModels.grad(um, x) ≈ NLPModels.grad(ref, x)
+                @test NLPModels.cons(um, x) ≈ NLPModels.cons(ref, x)
+                res = NLPModelsIpopt.ipopt(um; print_level = 0)
+                @test res.solution ≈ fill(2.0, N) atol = 1e-5
+                # And the bundled library is still alive next to it.
+                @test NLPModels.obj(
+                    CNLPModels.CNLPModel(lib, 5; prefix = r.prefix),
+                    fill(1.0, 5)) ≈ 5.0
+            else
+                # The Python leg below is the consumer for this form here.
+                @info "in-process unbundled loading is Linux-only; skipped"
+            end
         end
 
         @testset "the Python consumer reads the same model" begin
@@ -207,17 +231,24 @@ function runtests()
                 ok && (py = cand; break)
             end
 
+            # Both forms go through the same script: the bundled library and
+            # the unbundled single file, which Python loads as-is.
+            flatlib = joinpath(
+                OUT, "flat", "libflat." * Base.BinaryPlatforms.platform_dlext())
+            pylibs = [(r.libpath, r.prefix)]
+            isfile(flatlib) && push!(pylibs, (flatlib, "flat"))
             if py === nothing || !isdir(pysrc)
                 @info "skipping the Python leg" python = py pysrc_exists = isdir(pysrc)
                 @test_skip false
             else
+                for (pylib, pyprefix) in pylibs
                 N = 12
                 outfile = joinpath(mktempdir(), "py.txt")
                 env = copy(ENV)
                 sep = Sys.iswindows() ? ";" : ":"     # PATH separator, not ':' everywhere
                 env["PYTHONPATH"] =
                     pysrc * (haskey(env, "PYTHONPATH") ? sep * env["PYTHONPATH"] : "")
-                run(setenv(`$py $script $(r.libpath) $(r.prefix) $N $outfile`, env))
+                run(setenv(`$py $script $(pylib) $(pyprefix) $N $outfile`, env))
 
                 vals = Dict{String,Vector{Float64}}()
                 for line in eachline(outfile)
@@ -251,6 +282,7 @@ function runtests()
                 @test Int.(vals["hess_rows"]) == hr
                 @test Int.(vals["hess_cols"]) == hc
                 @test vals["hess"] ≈ NLPModels.hess_coord(ref, x, y; obj_weight = 0.5)
+                end
             end
         end
 

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -58,8 +58,11 @@ function runtests()
         end
 
         # Compiling takes minutes, so the library is built once and every
-        # behavioural test below reads that one artifact.
-        r = compile_library(joinpath(OUT, "rosen"), build(), 4)
+        # behavioural test below reads that one artifact.  Bundled explicitly:
+        # this is the bundle-path coverage (the default — unbundled — has its
+        # own testset below), and the bundle is the form CNLPModels.jl can
+        # load on every OS.
+        r = compile_library(joinpath(OUT, "rosen"), build(), 4; bundle = true)
 
         @testset "the library exists and loads" begin
             @test isfile(r.libpath)
@@ -135,9 +138,11 @@ function runtests()
             ref = ExaModel(c)
 
             # Compiled through the `@name` spelling: installs on the search
-            # path, with the prefix defaulting to the name.
+            # path, with the prefix defaulting to the name.  Bundled, so the
+            # in-Julia consumption below works on every OS — and a second
+            # bundle in one process is the salt-collision regression case.
             f = withenv("CNLPMODELS_PATH" => OUT) do
-                compile_library("@fixed", c)
+                compile_library("@fixed", c; bundle = true)
             end
             @test f.outdir == joinpath(OUT, "fixed")
             @test f.prefix == "fixed"
@@ -170,10 +175,11 @@ function runtests()
             @test m2.meta.nvar == n
         end
 
-        @testset "bundle = false is a single file, loadable everywhere" begin
-            # One ~2 MB library rather than an 80 MB directory, linked against
-            # the installed Julia.
-            u = compile_library(joinpath(OUT, "flat"), build(), 4; bundle = false)
+        @testset "the default — unbundled — is a single file, loadable everywhere" begin
+            # No `bundle` argument: this is what `compile_library` emits by
+            # default — one ~2 MB library rather than an 80 MB directory,
+            # linked against the installed Julia.
+            u = compile_library(joinpath(OUT, "flat"), build(), 4)
             @test isfile(u.libpath)
             @test u.libpath == joinpath(
                 u.outdir, "lib" * u.prefix * "." * Base.BinaryPlatforms.platform_dlext())


### PR DESCRIPTION
`compile_library` now emits a single ~2 MB shared library by default, linked against the Julia installation it was built with; `bundle = true` remains available for the self-contained ~80 MB privatized-runtime directory.

This rides on madsuite-org/CNLPModels.jl#5, which teaches `CNLPModels.load` to provision an unbundled library with a load-time private runtime on Linux (loading one into a Julia host used to abort the process). Python (`cnlpmodels`) and C consumers load either form as-is on every OS. The docstring's consumer table and the mechanism notes are updated accordingly.

Test changes: the shared `rosen` artifact and the `@fixed` install are now compiled with `bundle = true` explicitly — they are the bundle-path coverage, the form Julia can consume on every OS, and two bundles in one process is the salt-collision regression case — while the `flat` testset drops its explicit kwarg and exercises the default. Suite is 97/97 locally on Linux.

**Merge order:** the ExaModelsC test environment resolves CNLPModels from `master`, so the in-process unbundled leg of CI here needs madsuite-org/CNLPModels.jl#5 merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)