### PR TITLE
ExaModelsC: emit several models into one library

### DIFF
--- a/ExaModelsC/Project.toml
+++ b/ExaModelsC/Project.toml
@@ -6,6 +6,7 @@ authors = ["Sungho Shin <sushin@mit.edu>"]
 [deps]
 ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
 JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -52,6 +52,25 @@ m = cnlpmodels.CModel(lib, 1000, prefix="rosen")
 Both consumers default `prefix` to `"rec"` when handed a library handle, while
 `compile_library` defaults it to the output directory's name — pass it
 explicitly unless those coincide.  The test suite exercises both.
+
+## Several models in one library
+
+A library can carry more than one model, each under its own symbol prefix.
+Name them, and the consumers select by the same name:
+
+```julia
+compile_library("@grid", :acopf => (ac_core, 100), :dcopf => (dc_core, 100))
+```
+```julia
+CNLPModel("@grid", :acopf, 100)                  # Julia
+```
+```python
+cnlpmodels.CModel("grid", 100, prefix="acopf")   # Python — a bare name, no sigil
+```
+
+They share the library file and, in a bundle, its one privatized ~80 MB Julia
+runtime — which is the reason to co-package a family of models rather than emit
+a library each.
 """
 module ExaModelsC
 
@@ -67,6 +86,15 @@ export compile_library
 # its own environment, never registered.  A constant UUID is therefore safe and
 # saves a UUIDs dependency.
 const _GEN_UUID = "b41c7e02-9f3d-4a58-8e6c-2d0f5a7c9b13"
+
+# One model's compiled form: its prefix, its concretized core, the example value
+# whose types `juliac` needs, and how `<prefix>_new(n)` rebuilds it (`field`).
+struct ModelSpec
+    prefix::String
+    core::Any
+    arg::Any
+    field::Any
+end
 
 """
     compile_library(out, core, args...; prefix = basename(out), trim = "safe",
@@ -157,11 +185,17 @@ function returns a `Cint` status, `0` on success, and none of them throws
 across the boundary.
 
 `P_new` takes a single integer, so the recipe form applies when the example
-`arg` is an `Integer`, or a `NamedTuple` holding exactly one integer field —
-the "scalable model" case (`rosenbrock` at size `N`).  Structured
-instantiation (the schema + builder ABI, for data-defined models such as OPF)
-is not built yet; `compile_library` says so rather than emitting a library
-that would fail at load.
+`arg` is an `Integer` — the "scalable model" case (`rosenbrock` at size `N`).
+Structured instantiation (the schema + builder ABI, for data-defined models
+such as OPF) is not built yet; `compile_library` says so rather than emitting
+a library that would fail at load, and prints the schema the model would
+need.  That is the only surface, so several example values, a float, an array,
+a table, or a `NamedTuple` are all refused for now.
+
+## Several models in one library
+
+Give `:name => core` pairs instead of a single core to put more than one model
+in the library — see the method below.
 """
 function compile_library(
     out::AbstractString,
@@ -172,6 +206,111 @@ function compile_library(
     bundle::Bool = false,
     verbose::Bool = false,
 )
+    spec = _model_spec(prefix, core, args)
+    r = _compile([spec], out, prefix, trim, bundle, verbose)
+    # One model keeps the singular field it has always returned.
+    return (; libpath = r.libpath, outdir = r.outdir, prefix = spec.prefix)
+end
+
+"""
+    compile_library(out, :name1 => (core1, args1...), :name2 => core2, ...;
+                    trim = "safe", bundle = true, verbose = false)
+        -> (; libpath, outdir, prefixes)
+
+Compile **several models into one shared library**, each under its own symbol
+prefix — the same names the consumer selects with, `CNLPModel(lib, :name1,
+args...)`.
+
+Each model is a pair: the name, then either a bare `core` (a fixed model,
+taking no instantiation data) or a tuple `(core, args...)` giving the example
+values exactly as `ExaModel(core, ...)` would take them.
+
+```julia
+compile_library("@grid",
+    :acopf => (ac_core, 100),      # acopf_new(n) inside libgrid.so
+    :dcopf => (dc_core, 100),      # dcopf_new(n) in the same library
+    :fixed => small_core,          # fixed_nargs() == 0
+)
+CNLPModel("@grid", :acopf, 100)    # the consumer's spelling
+```
+
+The models share one library file and, in a bundle, one privatized ~80 MB Julia
+runtime — which is the reason to co-package them rather than emit one library
+each. They are otherwise independent: separate cores, separate instance tables,
+separate ids.
+
+The library FILE is named after `out` (`@grid` → `libgrid.so`), not after any
+one model, so `prefix =` has no meaning here and is not accepted — the model
+names supply the prefixes. Every other keyword behaves as in the single-model
+form.
+
+Each model is subject to the same restriction as the single-model form: one
+integer example value, or none for a fixed model. The schema + builder surface
+(several arguments, arrays, tables) is not emitted yet, for any model.
+"""
+function compile_library(
+    out::AbstractString,
+    models::Pair{Symbol}...;
+    trim::AbstractString = "safe",
+    bundle::Bool = false,
+    verbose::Bool = false,
+)
+    isempty(models) && throw(ArgumentError("give at least one `:name => core` model"))
+    specs = ModelSpec[
+        _model_spec(String(name), _core_and_args(name, value)...) for (name, value) in models
+    ]
+    _check_distinct(specs)
+    # The FILE is named after `out`; the models are named by their symbols.
+    r = _compile(specs, out, _default_out_prefix(out), trim, bundle, verbose)
+    return (; libpath = r.libpath, outdir = r.outdir, prefixes = [s.prefix for s in specs])
+end
+
+# `:name => core` is a fixed model; `:name => (core, args...)` carries example
+# values. Anything else is named precisely here — the pair spelling is easy to
+# get subtly wrong, and a mistake that reached `_model_spec` would be reported
+# as though the core itself were at fault.
+_core_and_args(::Symbol, core::ExaModels.ExaCore) = (core, ())
+function _core_and_args(name::Symbol, value::Tuple)
+    isempty(value) && throw(
+        ArgumentError(
+            "`:$name => ()` names no core — give `:$name => core` for a fixed " *
+            "model, or `:$name => (core, args...)`.",
+        ),
+    )
+    first(value) isa ExaModels.ExaCore || throw(
+        ArgumentError(
+            "`:$name` must begin with an `ExaCore` — got a $(typeof(first(value))).",
+        ),
+    )
+    return (first(value), Base.tail(value))
+end
+_core_and_args(name::Symbol, value) = throw(
+    ArgumentError(
+        "`:$name => $(typeof(value))` is not a model — give `:$name => core`, or " *
+        "`:$name => (core, args...)` with the example values `ExaModel` takes.",
+    ),
+)
+
+# Two models under one prefix would emit duplicate `@ccallable` names, which
+# juliac reports as a redefinition inside a generated file. Caught here instead.
+function _check_distinct(specs::Vector{ModelSpec})
+    seen = Set{String}()
+    for s in specs
+        s.prefix in seen && throw(
+            ArgumentError(
+                "two models are both named `$(s.prefix)` — one library cannot " *
+                "carry the same symbol prefix twice.",
+            ),
+        )
+        push!(seen, s.prefix)
+    end
+    return specs
+end
+
+# The per-model validation both entry points share. Everything here is checked
+# BEFORE any code generation, so a bad model is reported in the caller's process
+# rather than as a compile error in a generated file nobody is looking at.
+function _model_spec(prefix::AbstractString, core::ExaModels.ExaCore, args::Tuple)
     _check_prefix(prefix)
     core = _concretize(core)
     if isempty(args)
@@ -183,38 +322,48 @@ function compile_library(
         # still reaches the probe, which rejects it just as loudly.)
         core.nargs isa Val{0} || throw(
             ArgumentError(
-                "this core declared $(_nargs_count(core.nargs)) placeholder(s) " *
-                "— give one example value per placeholder, as you would to " *
-                "`ExaModel(core, ...)`; its types are what the compiler needs.",
+                "`$prefix`: this core declared $(_nargs_count(core.nargs)) " *
+                "placeholder(s) — give one example value per placeholder, as you " *
+                "would to `ExaModel(core, ...)`; its types are what the compiler " *
+                "needs.",
             ),
         )
-        arg = nothing
-        field = FixedModel()
-    else
-        fields = _schema(args)
-        _is_scalar_new(fields) || throw(
-            ArgumentError(
-                "this recipe needs the schema + builder interface, which is not " *
-                "emitted yet — only a single integer placeholder (`<prefix>_new(n)`) " *
-                "is. Its schema would be: " * _schema_json(fields),
-            ),
-        )
-        arg = only(args)
-        field = nothing
+        return ModelSpec(String(prefix), core, nothing, FixedModel())
     end
-    out = _resolve_out(out, bundle)
+    fields = _schema(args)
+    _is_scalar_new(fields) || throw(
+        ArgumentError(
+            "`$prefix`: this recipe needs the schema + builder interface, which is " *
+            "not emitted yet — only a single integer placeholder " *
+            "(`$(prefix)_new(n)`) is. Its schema would be: " * _schema_json(fields),
+        ),
+    )
+    return ModelSpec(String(prefix), core, only(args), nothing)
+end
+
+# The shared back half: probe every model, generate one app carrying all of
+# them, compile once. `libname` names the library FILE (`lib<libname>.<ext>`) —
+# the library's identity to a consumer resolving an `@name` or a bundle
+# directory, and distinct from the models' prefixes as soon as there is more
+# than one model.
+function _compile(specs::Vector{ModelSpec}, out, libname, trim, bundle, verbose)
+    outdir = _resolve_out(out, bundle)
 
     # Instantiate here, in this process, before generating anything.  A core
     # that cannot be instantiated produces a library that cannot be loaded, and
-    # the failure is far cheaper to read now than after a juliac run.
-    probe = ExaModels.ExaModel(core, arg)
-    verbose && @info "compile_library: core instantiates" nvar = probe.meta.nvar ncon =
-        probe.meta.ncon prefix
+    # the failure is far cheaper to read now than after a juliac run — the more
+    # so with several models, where one bad core would waste the whole compile.
+    for s in specs
+        probe = ExaModels.ExaModel(s.core, s.arg)
+        verbose && @info "compile_library: core instantiates" prefix = s.prefix nvar =
+            probe.meta.nvar ncon = probe.meta.ncon
+    end
 
-    appdir = _generate_app(core, arg, field, prefix)
-    verbose && @info "compile_library: generated app" appdir
+    appdir = _generate_app(specs, libname)
+    verbose &&
+        @info "compile_library: generated app" appdir models = [s.prefix for s in specs]
 
-    return _drive_juliac(appdir, prefix, out, trim, bundle, verbose)
+    return _drive_juliac(appdir, libname, outdir, trim, bundle, verbose)
 end
 
 
@@ -443,33 +592,46 @@ end
 
 # ── Generating the app package ────────────────────────────────────────────────
 
-function _generate_app(core, arg, field, prefix::AbstractString)
+function _generate_app(specs::Vector{ModelSpec}, libname::AbstractString)
     appdir = mktempdir(; prefix = "examodelsc_")
-    modname = "ExaLib_" * prefix
+    modname = _modname(libname)
     srcdir = joinpath(appdir, "src")
     mkpath(srcdir)
 
-    # The core and the example travel as data.  A core built against `arg` is
-    # plain data — trees of `Node1`/`Node2`/`Var` structs, arrays, tuples — with
-    # no closures in the evaluated path, which is what makes this possible at
-    # all.
-    Serialization.serialize(joinpath(srcdir, "core.jls"), core)
-    Serialization.serialize(joinpath(srcdir, "arg.jls"), arg)
+    # Each core and example travels as data, under its own model's name so any
+    # number of them can share one app.  A core built against `arg` is plain
+    # data — trees of `Node1`/`Node2`/`Var` structs, arrays, tuples — with no
+    # closures in the evaluated path, which is what makes this possible at all.
+    for s in specs
+        Serialization.serialize(joinpath(srcdir, "core_$(s.prefix).jls"), s.core)
+        Serialization.serialize(joinpath(srcdir, "arg_$(s.prefix).jls"), s.arg)
+    end
 
     # JuliaC copies the app into a fresh temporary directory before
     # instantiating, which silently breaks relative `path =` entries: they would
     # resolve against the copy's parent. Absolute from the start.
     exadir = abspath(joinpath(dirname(dirname(pathof(ExaModels)))))
-    pkgs = _core_packages(core)
+    # The union across every core: a package that owns a type inside ANY of
+    # them must be a dependency and an import of the one generated app.
+    pkgs = _Pkg[]
+    for s in specs
+        for p in _core_packages(s.core)
+            any(q -> q.uuid == p.uuid, pkgs) || push!(pkgs, p)
+        end
+    end
     write(joinpath(appdir, "Project.toml"), _project_toml(modname, exadir, pkgs))
-    write(
-        joinpath(srcdir, modname * ".jl"),
-        _module_source(modname, prefix, field, pkgs),
-    )
+    write(joinpath(srcdir, modname * ".jl"), _module_source(modname, specs, pkgs))
     return appdir
 end
 
 _toml_path(dir::AbstractString) = replace(dir, '\\' => '/')
+
+# The generated MODULE name must be a Julia identifier. The library FILE name
+# need not be — a consumer resolves `libmy-lib.so` out of a `my-lib/` bundle
+# quite happily — so the module name is sanitized here rather than the file
+# name being restricted. For a single model this is the prefix, already checked
+# by `_check_prefix`, and the sanitizing is a no-op.
+_modname(libname::AbstractString) = "ExaLib_" * replace(libname, r"[^A-Za-z0-9_]" => "_")
 
 function _project_toml(modname::AbstractString, exadir::AbstractString, pkgs = _Pkg[])
     deps = join(("""$(p.name) = "$(p.uuid)"\n""" for p in pkgs))
@@ -510,8 +672,7 @@ _arg_expr(::FixedModel) = "nothing"
 _nargs_value(::FixedModel) = 0
 _nargs_value(::Union{Nothing, Symbol}) = 1
 
-function _module_source(modname::AbstractString, p::AbstractString, field, pkgs = _Pkg[])
-    argexpr = _arg_expr(field)
+function _module_source(modname::AbstractString, specs::Vector{ModelSpec}, pkgs = _Pkg[])
     # Imported for their side effect on `Serialization`: a module has to be
     # loaded before a type it owns can be resolved by `PkgId`, and the
     # deserialize below is what needs them.  A dependency alone is not enough.
@@ -522,10 +683,26 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
     import ExaModels
     import Serialization
     $imports
+    $(join((_model_source(s) for s in specs), "\n"))
+    end # module $modname
+    """
+end
+
+# One model's share of the generated module. Every piece of per-model state
+# carries the prefix in its name, which is what lets any number of models
+# coexist in the one module: separate cores, separate instance tables,
+# separate ids. The entry points are `Base.@ccallable`, and juliac's
+# `add_ccallables` picks up all of them regardless of how many there are.
+function _model_source(s::ModelSpec)
+    p = s.prefix
+    argexpr = _arg_expr(s.field)
+    return """
+    # ── model `$p` ───────────────────────────────────────────────────────────
+
     # Deserialized at precompile time, so the core is baked into the package
     # image and no model-building code enters the compiled call graph.
-    const CORE = Serialization.deserialize(joinpath(@__DIR__, "core.jls"))
-    const ARG0 = Serialization.deserialize(joinpath(@__DIR__, "arg.jls"))
+    const CORE_$p = Serialization.deserialize(joinpath(@__DIR__, "core_$p.jls"))
+    const ARG0_$p = Serialization.deserialize(joinpath(@__DIR__, "arg_$p.jls"))
 
     # Building one model at precompile time fixes the concrete instance type.
     # Every runtime instantiation differs only in sizes, so they all land in
@@ -533,44 +710,44 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
     # placeholder-leak guard, which walks types reflectively and is not
     # trimmable — the check already ran, on this exact core, in the process
     # that called `compile_library`.
-    const MODELS = typeof(ExaModels.ExaModel(CORE, ARG0; check = Val(false)))[]
+    const MODELS_$p = typeof(ExaModels.ExaModel(CORE_$p, ARG0_$p; check = Val(false)))[]
 
-    @inline _valid(id::Cint) = 1 <= id <= length(MODELS)
+    @inline _valid_$p(id::Cint) = 1 <= id <= length(MODELS_$p)
 
     # How many instantiation arguments `$(p)_new` consumes (0 = fixed model,
     # `n` is ignored). Lets a consumer decide whether `args` are required
     # before instantiating anything.
     Base.@ccallable function $(p)_nargs()::Cint
-        return Cint($(_nargs_value(field)))
+        return Cint($(_nargs_value(s.field)))
     end
 
     Base.@ccallable function $(p)_new(n::Cint)::Cint
         try
-            push!(MODELS, ExaModels.ExaModel(CORE, $argexpr; check = Val(false)))
-            return Cint(length(MODELS))
+            push!(MODELS_$p, ExaModels.ExaModel(CORE_$p, $argexpr; check = Val(false)))
+            return Cint(length(MODELS_$p))
         catch
             return Cint(0)          # 0 is the failure value for _new
         end
     end
 
     Base.@ccallable function $(p)_nvar(id::Cint)::Cint
-        _valid(id) || return Cint(-1)
-        return Cint(MODELS[Int(id)].meta.nvar)
+        _valid_$p(id) || return Cint(-1)
+        return Cint(MODELS_$p[Int(id)].meta.nvar)
     end
 
     Base.@ccallable function $(p)_ncon(id::Cint)::Cint
-        _valid(id) || return Cint(-1)
-        return Cint(MODELS[Int(id)].meta.ncon)
+        _valid_$p(id) || return Cint(-1)
+        return Cint(MODELS_$p[Int(id)].meta.ncon)
     end
 
     Base.@ccallable function $(p)_nnzj(id::Cint)::Cint
-        _valid(id) || return Cint(-1)
-        return Cint(MODELS[Int(id)].meta.nnzj)
+        _valid_$p(id) || return Cint(-1)
+        return Cint(MODELS_$p[Int(id)].meta.nnzj)
     end
 
     Base.@ccallable function $(p)_nnzh(id::Cint)::Cint
-        _valid(id) || return Cint(-1)
-        return Cint(MODELS[Int(id)].meta.nnzh)
+        _valid_$p(id) || return Cint(-1)
+        return Cint(MODELS_$p[Int(id)].meta.nnzh)
     end
 
     Base.@ccallable function $(p)_meta(
@@ -581,9 +758,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
         lcon::Ptr{Cdouble},
         ucon::Ptr{Cdouble},
     )::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             n = m.meta.nvar
             k = m.meta.ncon
             copyto!(unsafe_wrap(Array, x0, n), m.meta.x0)
@@ -600,9 +777,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
     end
 
     Base.@ccallable function $(p)_obj(id::Cint, x::Ptr{Cdouble}, out::Ptr{Cdouble})::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             unsafe_store!(out, ExaModels.obj(m, unsafe_wrap(Array, x, m.meta.nvar)))
             return Cint(0)
         catch
@@ -611,9 +788,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
     end
 
     Base.@ccallable function $(p)_grad(id::Cint, x::Ptr{Cdouble}, g::Ptr{Cdouble})::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             n = m.meta.nvar
             ExaModels.grad!(m, unsafe_wrap(Array, x, n), unsafe_wrap(Array, g, n))
             return Cint(0)
@@ -623,9 +800,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
     end
 
     Base.@ccallable function $(p)_cons(id::Cint, x::Ptr{Cdouble}, c::Ptr{Cdouble})::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             k = m.meta.ncon
             k == 0 && return Cint(0)
             ExaModels.cons_nln!(
@@ -644,9 +821,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
         rows::Ptr{Cint},
         cols::Ptr{Cint},
     )::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             nz = m.meta.nnzj
             nz == 0 && return Cint(0)
             ExaModels.jac_structure!(
@@ -661,9 +838,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
     end
 
     Base.@ccallable function $(p)_jac(id::Cint, x::Ptr{Cdouble}, vals::Ptr{Cdouble})::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             nz = m.meta.nnzj
             nz == 0 && return Cint(0)
             ExaModels.jac_coord!(
@@ -682,9 +859,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
         rows::Ptr{Cint},
         cols::Ptr{Cint},
     )::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             nz = m.meta.nnzh
             nz == 0 && return Cint(0)
             ExaModels.hess_structure!(
@@ -705,9 +882,9 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
         obj_weight::Cdouble,
         vals::Ptr{Cdouble},
     )::Cint
-        _valid(id) || return Cint(1)
+        _valid_$p(id) || return Cint(1)
         try
-            m = MODELS[Int(id)]
+            m = MODELS_$p[Int(id)]
             nz = m.meta.nnzh
             nz == 0 && return Cint(0)
             ExaModels.hess_coord!(
@@ -723,13 +900,12 @@ function _module_source(modname::AbstractString, p::AbstractString, field, pkgs 
         end
     end
 
-    end # module $modname
     """
 end
 
 # ── Driving juliac ────────────────────────────────────────────────────────────
 
-function _drive_juliac(appdir, prefix, out, trim, bundle, verbose)
+function _drive_juliac(appdir, libname, out, trim, bundle, verbose)
     outdir = abspath(out)
     mkpath(outdir)
 
@@ -742,13 +918,13 @@ function _drive_juliac(appdir, prefix, out, trim, bundle, verbose)
         verbose = verbose,
     )
     JuliaC.compile_products(img)
-    return _link(Val(bundle), img, prefix, outdir)
+    return _link(Val(bundle), img, libname, outdir)
 end
 
 const _DLEXT = Base.BinaryPlatforms.platform_dlext()
 
 # ── bundled: carries a privatized runtime; loadable from anything ────────────
-function _link(::Val{true}, img, prefix, outdir)
+function _link(::Val{true}, img, libname, outdir)
     # The bundle owns its directory: the bundler refuses to overwrite an
     # existing one, and privatized runtime files carry randomized names that
     # would otherwise accumulate across rebuilds.  Removal is per-entry and
@@ -763,7 +939,7 @@ function _link(::Val{true}, img, prefix, outdir)
 
     link = JuliaC.LinkRecipe(
         image_recipe = img,
-        outname = joinpath(outdir, "lib" * prefix),
+        outname = joinpath(outdir, "lib" * libname),
         rpath = JuliaC.RPATH_BUNDLE,
     )
     JuliaC.link_products(link)
@@ -785,16 +961,16 @@ function _link(::Val{true}, img, prefix, outdir)
     end)
 
     libroot = Sys.iswindows() ? "bin" : "lib"
-    libpath = joinpath(outdir, libroot, "lib" * prefix * "." * _DLEXT)
+    libpath = joinpath(outdir, libroot, "lib" * libname * "." * _DLEXT)
     isfile(libpath) || error("juliac produced no library at $libpath")
-    return (; libpath, outdir, prefix)
+    return (; libpath, outdir, libname)
 end
 
 # ── unbundled: one file, linked against the installed Julia ─────────────────
-function _link(::Val{false}, img, prefix, outdir)
+function _link(::Val{false}, img, libname, outdir)
     # Not cleared: without a bundle each model is a single file, so a directory
     # may hold several and wiping it would delete a sibling.
-    libpath = joinpath(outdir, "lib" * prefix * "." * _DLEXT)
+    libpath = joinpath(outdir, "lib" * libname * "." * _DLEXT)
     link = JuliaC.LinkRecipe(
         image_recipe = img,
         outname = splitext(libpath)[1],
@@ -802,7 +978,7 @@ function _link(::Val{false}, img, prefix, outdir)
     )
     JuliaC.link_products(link)
     isfile(libpath) || error("juliac produced no library at $libpath")
-    return (; libpath, outdir, prefix)
+    return (; libpath, outdir, libname)
 end
 
 end # module ExaModelsC

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -952,19 +952,28 @@ end
 function _argfun_call(prefix, f)
     m = parentmodule(f)
     n = nameof(f)
-    ok = try
-        isdefined(m, n) && getfield(m, n) === f && Base.moduleroot(m) === m &&
-            _owning_package(m) !== nothing
+    own = try
+        (isdefined(m, n) && getfield(m, n) === f && Base.moduleroot(m) === m) ?
+            _owning_package(m) : nothing
     catch
-        false
+        nothing
     end
+    # The owning package's name matching the module's own is what separates
+    # "defined by a package" from "defined by its EXTENSION".  An extension
+    # passes every root-module test — an extension is its own moduleroot, and
+    # `_owning_package` deliberately maps it to its parent — but the generated
+    # app imports only packages, so a call spelled `SomePkgExt.f` names a
+    # module the app never has.  Without this check that surfaces as an
+    # UndefVarError inside generated code, minutes into juliac.
+    ok = own !== nothing && own.name == string(nameof(m))
     ok || throw(
         ArgumentError(
-            "`$prefix`: `argfun` must be a named function defined by a package — " *
-            "the generated library calls it by name, from another process, so a " *
-            "function defined in a script or the REPL cannot be reached. Got " *
-            "$(repr(f)) in module $m; define it at the top level of a package " *
-            "and pass that.",
+            "`$prefix`: `argfun` must be a named function defined at the top " *
+            "level of a PACKAGE — the generated library calls it by name, from " *
+            "another process, so a function defined in a script, the REPL, or " *
+            "a package extension cannot be reached. Got $(repr(f)) in module " *
+            "$m; define it in the package itself (for an extension, move it " *
+            "to the parent package) and pass that.",
         ),
     )
     return string(nameof(m), ".", n)

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -951,15 +951,18 @@ function _argfun_call(prefix, f)
     m = parentmodule(f)
     n = nameof(f)
     ok = try
-        isdefined(m, n) && getfield(m, n) === f && Base.moduleroot(m) === m
+        isdefined(m, n) && getfield(m, n) === f && Base.moduleroot(m) === m &&
+            _owning_package(m) !== nothing
     catch
         false
     end
     ok || throw(
         ArgumentError(
             "`$prefix`: `argfun` must be a named function defined by a package — " *
-            "the generated library calls it by name. Got $(repr(f)) in module " *
-            "$m; define it at the top level of your package and pass that.",
+            "the generated library calls it by name, from another process, so a " *
+            "function defined in a script or the REPL cannot be reached. Got " *
+            "$(repr(f)) in module $m; define it at the top level of a package " *
+            "and pass that.",
         ),
     )
     return string(nameof(m), ".", n)

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -175,22 +175,31 @@ is a complete model, so `compile_library(out, core)` compiles it as-is:
 no instantiation data is required.  A core that *declared* placeholders
 (`nargs = Val(N)`, `N > 0`) is refused without examples.
 
-The library exports, for `prefix` `P`: `P_nargs() -> 0 or 1` (how many
-instantiation arguments `P_new` consumes), `P_new(n) -> id` (a positive
-instance id; any number of instances may coexist), then id-first `P_nvar`,
-`P_ncon`, `P_nnzj`, `P_nnzh`, `P_meta`, `P_obj`, `P_grad`, `P_cons`,
-`P_jac_structure`, `P_jac`, `P_hess_structure`, `P_hess`.  Indices are 1-based;
-the Hessian is the lower triangle of `obj_weight * ∇²f + Σᵢ yᵢ ∇²cᵢ`; every
-function returns a `Cint` status, `0` on success, and none of them throws
-across the boundary.
+The library exports, for `prefix` `P`, one of two **instantiation surfaces**,
+then the shared evaluators — id-first `P_nvar`, `P_ncon`, `P_nnzj`, `P_nnzh`,
+`P_meta`, `P_obj`, `P_grad`, `P_cons`, `P_jac_structure`, `P_jac`,
+`P_hess_structure`, `P_hess`.  Indices are 1-based; the Hessian is the lower
+triangle of `obj_weight * ∇²f + Σᵢ yᵢ ∇²cᵢ`; every function returns a `Cint`
+status, `0` on success, and none of them throws across the boundary.
 
-`P_new` takes a single integer, so the recipe form applies when the example
-`arg` is an `Integer` — the "scalable model" case (`rosenbrock` at size `N`).
-Structured instantiation (the schema + builder ABI, for data-defined models
-such as OPF) is not built yet; `compile_library` says so rather than emitting
-a library that would fail at load, and prints the schema the model would
-need.  That is the only surface, so several example values, a float, an array,
-a table, or a `NamedTuple` are all refused for now.
+**One integer** (`rosenbrock` at size `N` — a bare `Integer` example, or a
+`NamedTuple` holding exactly one): `P_new(n) -> id` (a positive instance id;
+any number of instances may coexist), and `P_nargs() -> 0 or 1` saying whether
+`n` is consumed or ignored (0 is the fixed-model case).
+
+**Anything else** — several example values, floats, arrays, tables (vectors
+of NamedTuples), or NamedTuples of these, exactly as `ExaModel` takes them —
+gets the schema + builder ABI instead of `P_new`: `P_schema` publishes a JSON
+description of the fields, and `P_data_begin` / `P_set_scalar_{i64,f64}` /
+`P_set_array_{i64,f64}` / `P_set_col_{i64,f64}` / `P_data_ready` /
+`P_new_from_data -> id` take the values by field name and reassemble the
+`ExaModel` arguments.  A `NamedTuple` example flattens into one schema field
+per entry, named by its key; bare values are named `arg1`, `arg2`, ... by
+position.  Both consumers already speak this surface, binding one value per
+field positionally — `CNLPModel(lib, 3, lo, v)` — so a compiled model is
+consumed the way it was written.  Builder examples must be `Int64`/`Float64`
+exactly (as scalars, `Vector`s, or table entries): the example's type IS the
+compiled storage's type.
 
 ## Several models in one library
 
@@ -244,9 +253,10 @@ one model, so `prefix =` has no meaning here and is not accepted — the model
 names supply the prefixes. Every other keyword behaves as in the single-model
 form.
 
-Each model is subject to the same restriction as the single-model form: one
-integer example value, or none for a fixed model. The schema + builder surface
-(several arguments, arrays, tables) is not emitted yet, for any model.
+Each model gets whichever instantiation surface its examples call for, exactly
+as in the single-model form: `P_new(n)` for one integer, the schema + builder
+ABI for anything else, per prefix — the surfaces coexist freely in one
+library.
 """
 function compile_library(
     out::AbstractString,
@@ -330,15 +340,18 @@ function _model_spec(prefix::AbstractString, core::ExaModels.ExaCore, args::Tupl
         )
         return ModelSpec(String(prefix), core, nothing, FixedModel())
     end
-    fields = _schema(args)
-    _is_scalar_new(fields) || throw(
-        ArgumentError(
-            "`$prefix`: this recipe needs the schema + builder interface, which is " *
-            "not emitted yet — only a single integer placeholder " *
-            "(`$(prefix)_new(n)`) is. Its schema would be: " * _schema_json(fields),
-        ),
-    )
-    return ModelSpec(String(prefix), core, only(args), nothing)
+    bm = _builder_model(args)
+    # One integer placeholder — bare, or a one-key NamedTuple — keeps the
+    # `P_new(n)` fast path: one C call, no builder.  The two surfaces are
+    # disjoint on purpose: a library exports `P_new` exactly when its schema
+    # is a single integer scalar, which is what lets a consumer route a lone
+    # integer without guessing.
+    if _is_scalar_new(bm.fields)
+        spec = only(bm.argspec)
+        field = spec isa String ? nothing : first(only(spec))
+        return ModelSpec(String(prefix), core, only(args), field)
+    end
+    return ModelSpec(String(prefix), core, args, bm)
 end
 
 # The shared back half: probe every model, generate one app carrying all of
@@ -354,7 +367,24 @@ function _compile(specs::Vector{ModelSpec}, out, libname, trim, bundle, verbose)
     # the failure is far cheaper to read now than after a juliac run — the more
     # so with several models, where one bad core would waste the whole compile.
     for s in specs
-        probe = ExaModels.ExaModel(s.core, s.arg)
+        # A builder spec carries its examples as a tuple, one per placeholder;
+        # the other forms carry a single value (or `nothing` for a fixed core).
+        probe = try
+            s.arg isa Tuple ? ExaModels.ExaModel(s.core, s.arg...) :
+            ExaModels.ExaModel(s.core, s.arg)
+        catch err
+            # A shape mismatch between the examples and how the core reads its
+            # placeholders (a NamedTuple where a bare size is expected, a
+            # missing key, ...) surfaces here — as the caller's error, before
+            # minutes are spent compiling.
+            throw(
+                ArgumentError(
+                    "`$(s.prefix)`: the example values do not instantiate this " *
+                    "core — `ExaModel(core, example...)` failed with: " *
+                    sprint(showerror, err),
+                ),
+            )
+        end
         verbose && @info "compile_library: core instantiates" prefix = s.prefix nvar =
             probe.meta.nvar ncon = probe.meta.ncon
     end
@@ -418,11 +448,13 @@ _default_out_prefix(out::AbstractString) =
 
 # ── Reading the example arguments ─────────────────────────────────────────────
 #
-# The schema is derived from the example values' TYPES, one field per
-# placeholder.  Placeholders are positional, so the fields are named `arg1`,
-# `arg2`, ... — and a consumer binds its own arguments positionally against
-# that field order, `CNLPModel(lib, arg1, arg2, ...)`, the same spelling the
-# example values are given in here.
+# The schema is derived from the example values' TYPES.  A bare number or
+# vector is one field, named `arg1`, `arg2`, ... by position; a NamedTuple
+# example — the shape `ExaModel` takes for a source carrying several values —
+# flattens into one field per entry, named by its key.  A consumer binds its
+# own values positionally against the flat field order,
+# `CNLPModel(lib, v1, v2, ...)`, and the library reassembles the NamedTuples
+# before instantiating.
 
 struct Field
     name::String
@@ -483,6 +515,108 @@ end
 # `P_new(n)` stays as the fast path: one integer placeholder needs no builder.
 _is_scalar_new(fields) =
     length(fields) == 1 && fields[1].kind == "scalar" && fields[1].type == "i64"
+
+# Everything else gets the schema + builder surface (ABI v2): the consumer
+# opens a builder, sets each field by name, and `P_new_from_data` reassembles
+# the `ExaModel` arguments exactly as the example values were given here.
+# `argspec` records that mapping — one entry per `ExaModel` positional
+# argument:
+#
+#   a `String`                      — a bare value, stored under that field
+#   a `Vector{Pair{Symbol,String}}` — a NamedTuple, one (key => field) per entry
+struct BuilderModel
+    fields::Vector{Field}
+    argspec::Vector{Union{String, Vector{Pair{Symbol,String}}}}
+end
+
+# Builder storage is GENERATED from the example types, and the model vector's
+# element type is fixed by instantiating the example at precompile time — so
+# the example must BE the type the builder will reconstruct: Int64/Float64
+# exactly, as scalars, `Vector`s, or vectors of NamedTuples of them.  A looser
+# example (`Int32`, a range, `Real[]`) would compile a MODELS vector the
+# reconstruction cannot feed, and the mismatch would surface only inside the
+# compiled library; refused here instead.
+_check_exact(name, v::Union{Int64, Float64, Vector{Int64}, Vector{Float64}}) = v
+function _check_exact(name, v::Vector{T}) where {T <: NamedTuple}
+    (isconcretetype(T) && all(t -> t <: Union{Int64, Float64}, fieldtypes(T))) ||
+        _exact_err(name, v)
+    return v
+end
+_check_exact(name, v) = _exact_err(name, v)
+_exact_err(name, v) = throw(
+    ArgumentError(
+        "`$name`: builder examples must be Int64/Float64 values — as scalars, " *
+        "as Vector{Int64}/Vector{Float64}, or as a Vector of NamedTuples of " *
+        "them (a table); got $(typeof(v)). The storage the library compiles " *
+        "is exactly the example's type.",
+    ),
+)
+
+function _builder_model(args)
+    fields = Field[]
+    argspec = Union{String, Vector{Pair{Symbol,String}}}[]
+    seen = Set{String}()
+    claim = function (name, where_)
+        name in seen && throw(
+            ArgumentError(
+                "two schema fields would both be named `$name` (the second from " *
+                "$where_) — field names come from NamedTuple keys and `argN` " *
+                "positions, and must be distinct across all placeholders; " *
+                "rename one.",
+            ),
+        )
+        push!(seen, name)
+        return name
+    end
+    for (i, a) in enumerate(args)
+        if a isa NamedTuple
+            entries = Pair{Symbol,String}[]
+            for k in keys(a)
+                name = claim(String(k), "argument $i")
+                push!(fields, _field(name, _check_exact(name, getfield(a, k))))
+                push!(entries, k => name)
+            end
+            push!(argspec, entries)
+        else
+            name = claim("arg$i", "argument $i")
+            push!(fields, _field(name, _check_exact(name, a)))
+            push!(argspec, name)
+        end
+    end
+    # Tables flatten further, into one storage slot per column — those names
+    # must be distinct too, and a table needs at least one column to have an
+    # element type at all.
+    slots = String[]
+    for f in fields
+        f.kind == "table" && isempty(f.columns) && throw(
+            ArgumentError(
+                "`$(f.name)`: the example table has no columns — give " *
+                "NamedTuples with at least one entry.",
+            ),
+        )
+        append!(slots, (s for (s, _, _) in _slots(f)))
+    end
+    allunique(slots) || throw(
+        ArgumentError(
+            "field and table-column names collide once flattened to storage " *
+            "slots ($(join(slots, ", "))) — rename one of the duplicates.",
+        ),
+    )
+    return BuilderModel(fields, argspec)
+end
+
+# The flat storage behind a builder: (slot identifier, storage type, zero
+# value), one slot per scalar/array field and per table column.  Each slot
+# also carries a `<slot>_set::Bool` beside it in the generated struct.
+function _slots(f::Field)
+    jt(t) = t == "i64" ? "Int64" : "Float64"
+    jz(t) = t == "i64" ? "0" : "0.0"
+    jvt(t) = t == "i64" ? "Vector{Int64}" : "Vector{Float64}"
+    jvz(t) = t == "i64" ? "Int64[]" : "Float64[]"
+    f.kind == "scalar" && return [(f.name, jt(f.type), jz(f.type))]
+    f.kind == "array" && return [(f.name, jvt(f.type), jvz(f.type))]
+    return [("$(f.name)_$(c.first)", jvt(c.second), jvz(c.second)) for c in f.columns]
+end
 
 # The prefix becomes a C symbol and a Julia identifier in generated source, so
 # it has to be one. Checked here rather than discovered as a syntax error in a
@@ -672,6 +806,249 @@ _arg_expr(::FixedModel) = "nothing"
 _nargs_value(::FixedModel) = 0
 _nargs_value(::Union{Nothing, Symbol}) = 1
 
+# ── Generating one model's instantiation surface ─────────────────────────────
+#
+# A fixed or one-integer model gets `P_nargs` + `P_new(n)`.  Everything else
+# gets the schema + builder surface (ABI v2) and NO `P_new` — the consumers
+# rely on that disjointness to route a lone integer.  All storage is
+# concretely typed from the example values, so `--trim=safe` sees no dynamic
+# containers.
+
+function _instantiation_source(p::AbstractString, field::Union{Nothing, Symbol, FixedModel})
+    argexpr = _arg_expr(field)
+    return """
+    # How many instantiation arguments `$(p)_new` consumes (0 = fixed model,
+    # `n` is ignored). Lets a consumer decide whether `args` are required
+    # before instantiating anything.
+    Base.@ccallable function $(p)_nargs()::Cint
+        return Cint($(_nargs_value(field)))
+    end
+
+    Base.@ccallable function $(p)_new(n::Cint)::Cint
+        try
+            push!(MODELS_$p, ExaModels.ExaModel(CORE_$p, $argexpr; check = Val(false)))
+            return Cint(length(MODELS_$p))
+        catch
+            return Cint(0)          # 0 is the failure value for _new
+        end
+    end
+"""
+end
+
+# How a slot is read back out of a builder when the model is instantiated: a
+# table reassembles into the example's row type, column by column.
+function _slot_expr(f::Field)
+    f.kind == "table" || return "B.$(f.name)"
+    row = join(("$(c.first) = B.$(f.name)_$(c.first)[_k]" for c in f.columns), ", ")
+    return "[(; $row) for _k in eachindex(B.$(f.name)_$(first(f.columns).first))]"
+end
+
+# One `if` arm per field a setter can legitimately name; a name that matches
+# no arm is status 1, the caller's error, not ours.
+function _setter_arms(fields, render)
+    isempty(fields) && return ""
+    return join((render(f) for f in fields), "") * "\n"
+end
+
+function _instantiation_source(p::AbstractString, bm::BuilderModel)
+    fields = bm.fields
+    byname = Dict(f.name => f for f in fields)
+    slots = [sl for f in fields for sl in _slots(f)]
+    json = _schema_json(fields)
+
+    decls = join(("        $s::$t\n        $(s)_set::Bool\n" for (s, t, _) in slots))
+    zeros = join(("$z, false" for (_, _, z) in slots), ", ")
+    flags = join(("B.$(s)_set" for (s, _, _) in slots), " && ")
+
+    scalar(f) = """
+            if f == $(repr(f.name))
+                B.$(f.name) = v
+                B.$(f.name)_set = true
+                return Cint(0)
+            end
+    """
+    array(f) = """
+            if f == $(repr(f.name))
+                B.$(f.name) = copy(unsafe_wrap(Array, v, Int(len)))
+                B.$(f.name)_set = true
+                return Cint(0)
+            end
+    """
+    col(f, c) = """
+            if t == $(repr(f.name)) && c == $(repr(c.first))
+                B.$(f.name)_$(c.first) = copy(unsafe_wrap(Array, v, Int(len)))
+                B.$(f.name)_$(c.first)_set = true
+                return Cint(0)
+            end
+    """
+    pick(kind, type) = [f for f in fields if f.kind == kind && f.type == type]
+    cols(type) = [
+        (f, c) for f in fields if f.kind == "table" for c in f.columns if c.second == type
+    ]
+
+    # Table columns must agree in length before rows can be reassembled.
+    samelen = join(
+        (
+            "        (" *
+            join(
+                ("length(B.$(f.name)_$(c.first)) == length(B.$(f.name)_$(first(f.columns).first))"
+                 for c in f.columns[2:end]),
+                " && ",
+            ) *
+            ") || return Cint(0)\n"
+            for f in fields if f.kind == "table" && length(f.columns) > 1
+        ),
+    )
+
+    asm = join(
+        (
+            spec isa String ? _slot_expr(byname[spec]) :
+            "(; " * join(("$(k) = $(_slot_expr(byname[n]))" for (k, n) in spec), ", ") * ")"
+            for spec in bm.argspec
+        ),
+        ",\n                ",
+    )
+
+    return """
+    # ── builder for `$p` (schema + typed setters, ABI v2) ────────────────────
+
+    const SCHEMA_$p = Vector{UInt8}($(repr(json)))
+
+    # Returns the schema's byte length; copies what fits in `cap`.
+    Base.@ccallable function $(p)_schema(buf::Ptr{UInt8}, cap::Cint)::Cint
+        n = length(SCHEMA_$p)
+        k = min(Int(cap), n)
+        if k > 0 && buf != Ptr{UInt8}(0)
+            GC.@preserve SCHEMA_$p unsafe_copyto!(buf, pointer(SCHEMA_$p), k)
+        end
+        return Cint(n)
+    end
+
+    # One concretely-typed slot per scalar/array field and per table column;
+    # the `_set` flags are what make completeness checkable without sentinels.
+    mutable struct Builder_$p
+$decls    end
+    Builder_$p() = Builder_$p($zeros)
+    const BUILDERS_$p = Builder_$p[]
+
+    @inline _bvalid_$p(b::Cint) = 1 <= b <= length(BUILDERS_$p)
+
+    Base.@ccallable function $(p)_data_begin()::Cint
+        try
+            push!(BUILDERS_$p, Builder_$p())
+            return Cint(length(BUILDERS_$p))
+        catch
+            return Cint(0)
+        end
+    end
+
+    Base.@ccallable function $(p)_set_scalar_i64(b::Cint, field::Ptr{UInt8}, v::Clonglong)::Cint
+        _bvalid_$p(b) || return Cint(1)
+        try
+            f = unsafe_string(field)
+            B = BUILDERS_$p[Int(b)]
+$(_setter_arms(pick("scalar", "i64"), scalar))            return Cint(1)
+        catch
+            return Cint(2)
+        end
+    end
+
+    Base.@ccallable function $(p)_set_scalar_f64(b::Cint, field::Ptr{UInt8}, v::Cdouble)::Cint
+        _bvalid_$p(b) || return Cint(1)
+        try
+            f = unsafe_string(field)
+            B = BUILDERS_$p[Int(b)]
+$(_setter_arms(pick("scalar", "f64"), scalar))            return Cint(1)
+        catch
+            return Cint(2)
+        end
+    end
+
+    Base.@ccallable function $(p)_set_array_i64(
+        b::Cint, field::Ptr{UInt8}, v::Ptr{Clonglong}, len::Cint,
+    )::Cint
+        _bvalid_$p(b) || return Cint(1)
+        try
+            f = unsafe_string(field)
+            B = BUILDERS_$p[Int(b)]
+$(_setter_arms(pick("array", "i64"), array))            return Cint(1)
+        catch
+            return Cint(2)
+        end
+    end
+
+    Base.@ccallable function $(p)_set_array_f64(
+        b::Cint, field::Ptr{UInt8}, v::Ptr{Cdouble}, len::Cint,
+    )::Cint
+        _bvalid_$p(b) || return Cint(1)
+        try
+            f = unsafe_string(field)
+            B = BUILDERS_$p[Int(b)]
+$(_setter_arms(pick("array", "f64"), array))            return Cint(1)
+        catch
+            return Cint(2)
+        end
+    end
+
+    Base.@ccallable function $(p)_set_col_i64(
+        b::Cint, table::Ptr{UInt8}, column::Ptr{UInt8}, v::Ptr{Clonglong}, len::Cint,
+    )::Cint
+        _bvalid_$p(b) || return Cint(1)
+        try
+            t = unsafe_string(table)
+            c = unsafe_string(column)
+            B = BUILDERS_$p[Int(b)]
+$(_setter_arms(cols("i64"), fc -> col(fc...)))            return Cint(1)
+        catch
+            return Cint(2)
+        end
+    end
+
+    Base.@ccallable function $(p)_set_col_f64(
+        b::Cint, table::Ptr{UInt8}, column::Ptr{UInt8}, v::Ptr{Cdouble}, len::Cint,
+    )::Cint
+        _bvalid_$p(b) || return Cint(1)
+        try
+            t = unsafe_string(table)
+            c = unsafe_string(column)
+            B = BUILDERS_$p[Int(b)]
+$(_setter_arms(cols("f64"), fc -> col(fc...)))            return Cint(1)
+        catch
+            return Cint(2)
+        end
+    end
+
+    # 1 iff every field is set and every table's columns agree in length.
+    Base.@ccallable function $(p)_data_ready(b::Cint)::Cint
+        _bvalid_$p(b) || return Cint(0)
+        B = BUILDERS_$p[Int(b)]
+        ($flags) || return Cint(0)
+$samelen        return Cint(1)
+    end
+
+    Base.@ccallable function $(p)_new_from_data(b::Cint)::Cint
+        $(p)_data_ready(b) == Cint(1) || return Cint(0)
+        try
+            B = BUILDERS_$p[Int(b)]
+            push!(MODELS_$p, ExaModels.ExaModel(
+                CORE_$p,
+                $asm;
+                check = Val(false),
+            ))
+            return Cint(length(MODELS_$p))
+        catch
+            return Cint(0)
+        end
+    end
+
+    # Informative — there is no `$(p)_new` here; the consumers bind one value
+    # per schema field, positionally, and instantiate through the builder.
+    Base.@ccallable function $(p)_nargs()::Cint
+        return Cint($(length(fields)))
+    end
+"""
+end
+
 function _module_source(modname::AbstractString, specs::Vector{ModelSpec}, pkgs = _Pkg[])
     # Imported for their side effect on `Serialization`: a module has to be
     # loaded before a type it owns can be resolved by `PkgId`, and the
@@ -695,7 +1072,9 @@ end
 # `add_ccallables` picks up all of them regardless of how many there are.
 function _model_source(s::ModelSpec)
     p = s.prefix
-    argexpr = _arg_expr(s.field)
+    # A builder spec's example is the whole tuple of values, splatted back the
+    # way `ExaModel` takes them; the other forms carry a single value.
+    example = s.field isa BuilderModel ? "ARG0_$p..." : "ARG0_$p"
     return """
     # ── model `$p` ───────────────────────────────────────────────────────────
 
@@ -710,26 +1089,11 @@ function _model_source(s::ModelSpec)
     # placeholder-leak guard, which walks types reflectively and is not
     # trimmable — the check already ran, on this exact core, in the process
     # that called `compile_library`.
-    const MODELS_$p = typeof(ExaModels.ExaModel(CORE_$p, ARG0_$p; check = Val(false)))[]
+    const MODELS_$p = typeof(ExaModels.ExaModel(CORE_$p, $example; check = Val(false)))[]
 
     @inline _valid_$p(id::Cint) = 1 <= id <= length(MODELS_$p)
 
-    # How many instantiation arguments `$(p)_new` consumes (0 = fixed model,
-    # `n` is ignored). Lets a consumer decide whether `args` are required
-    # before instantiating anything.
-    Base.@ccallable function $(p)_nargs()::Cint
-        return Cint($(_nargs_value(s.field)))
-    end
-
-    Base.@ccallable function $(p)_new(n::Cint)::Cint
-        try
-            push!(MODELS_$p, ExaModels.ExaModel(CORE_$p, $argexpr; check = Val(false)))
-            return Cint(length(MODELS_$p))
-        catch
-            return Cint(0)          # 0 is the failure value for _new
-        end
-    end
-
+$(_instantiation_source(p, s.field))
     Base.@ccallable function $(p)_nvar(id::Cint)::Cint
         _valid_$p(id) || return Cint(-1)
         return Cint(MODELS_$p[Int(id)].meta.nvar)

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -202,6 +202,23 @@ consumed the way it was written.  Builder examples must be `Int64`/`Float64`
 exactly (as scalars, `Vector`s, or table entries): the example's type IS the
 compiled storage's type.
 
+**An argument function** (`argfun = f`, or `:name => (core, f, example)` in
+the multi-model form — a function can never be a model argument, so second
+position is unambiguous) is the third surface: the library carries `f` and
+calls it at run time, so only `f`'s own argument crosses the boundary — one
+string (`P_new_str(const char *)`) or one integer (`P_new(n)`) — and the
+work that turns it into instantiation data happens inside the library.  It
+composes with the builder rather than competing: the builder passes
+structured data ACROSS the boundary, this keeps the data on the far side
+and passes a path.  `f` must be a named function a package owns — it is
+emitted by name, which is what `juliac` resolves statically — and it must
+return the argument TUPLE the core is instantiated with.  The example is
+`f`'s argument, and `f(example)` is probed before compiling.
+
+Every model also exports `P_argkind() -> 0 | 1 | 2 | 3` (fixed, `P_new(n)`,
+`P_new_str`, builder), so a consumer routes on the declared shape instead
+of probing for symbols.
+
 ## Several models in one library
 
 Give `:name => core` pairs instead of a single core to put more than one model
@@ -330,6 +347,11 @@ end
 # The per-model validation both entry points share. Everything here is checked
 # BEFORE any code generation, so a bad model is reported in the caller's process
 # rather than as a compile error in a generated file nobody is looking at.
+# The three-argument form: no argument function. Kept as the spelling for
+# every caller that has none, including the tests' hermetic probes.
+_model_spec(prefix::AbstractString, core::ExaModels.ExaCore, args::Tuple) =
+    _model_spec(prefix, core, nothing, args)
+
 function _model_spec(prefix::AbstractString, core::ExaModels.ExaCore, argfun, args::Tuple)
     _check_prefix(prefix)
     core = _concretize(core)

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -76,6 +76,7 @@ module ExaModelsC
 
 import ExaModels
 import JuliaC
+import Pkg
 import Random
 import Serialization
 import TOML
@@ -724,6 +725,28 @@ function _core_packages(core)
     return pkgs
 end
 
+"""
+    _developed_packages() -> Vector{_Pkg}
+
+Every package tracked by path in the caller's active environment, other than
+ExaModels itself (always carried separately). These become `[sources]` entries
+in the generated app so it compiles the same code the caller is running —
+without them, transitive dependencies resolve from the registry, and the app
+can silently compile DIFFERENT code than the process that produced the core
+(the build succeeds; the only trace is a path inside a stack frame).
+"""
+function _developed_packages()
+    out = _Pkg[]
+    for (uuid, info) in Pkg.dependencies()
+        info.is_tracking_path || continue
+        info.name == "ExaModels" && continue
+        src = info.source
+        src === nothing && continue
+        push!(out, _Pkg(info.name, uuid, abspath(src)))
+    end
+    return sort!(out; by = p -> p.name)
+end
+
 # ── Generating the app package ────────────────────────────────────────────────
 
 function _generate_app(specs::Vector{ModelSpec}, libname::AbstractString)
@@ -753,7 +776,14 @@ function _generate_app(specs::Vector{ModelSpec}, libname::AbstractString)
             any(q -> q.uuid == p.uuid, pkgs) || push!(pkgs, p)
         end
     end
-    write(joinpath(appdir, "Project.toml"), _project_toml(modname, exadir, pkgs))
+    # Every package the caller is DEVELOPING joins as a dependency and a path
+    # source, but NOT as an import: resolution needs the pin (measured — a
+    # verified `[deps]` + `[sources]` entry tracks the path with no import
+    # anywhere), while only the deserialization of a core's own types needs
+    # the import. Importing everything a caller happens to be developing
+    # would drag unrelated packages into every app's compile.
+    dev = [q for q in _developed_packages() if !any(r -> r.uuid == q.uuid, pkgs)]
+    write(joinpath(appdir, "Project.toml"), _project_toml(modname, exadir, pkgs, dev))
     write(joinpath(srcdir, modname * ".jl"), _module_source(modname, specs, pkgs))
     return appdir
 end
@@ -767,11 +797,14 @@ _toml_path(dir::AbstractString) = replace(dir, '\\' => '/')
 # by `_check_prefix`, and the sanitizing is a no-op.
 _modname(libname::AbstractString) = "ExaLib_" * replace(libname, r"[^A-Za-z0-9_]" => "_")
 
-function _project_toml(modname::AbstractString, exadir::AbstractString, pkgs = _Pkg[])
-    deps = join(("""$(p.name) = "$(p.uuid)"\n""" for p in pkgs))
+function _project_toml(
+    modname::AbstractString, exadir::AbstractString, pkgs = _Pkg[], dev = _Pkg[],
+)
+    both = vcat(pkgs, dev)
+    deps = join(("""$(p.name) = "$(p.uuid)"\n""" for p in both))
     # A path source rather than a version bound: the app must compile the same
     # code that produced the core, not merely something compatible with it.
-    sources = join(("""$(p.name) = {path = "$(_toml_path(p.dir))"}\n""" for p in pkgs))
+    sources = join(("""$(p.name) = {path = "$(_toml_path(p.dir))"}\n""" for p in both))
     return """
     name = "$modname"
     uuid = "$_GEN_UUID"

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -734,9 +734,7 @@ function _collect_modules!(mods::Set{Module}, seen::Base.IdSet{Any}, @nospeciali
 end
 
 # The package a module belongs to, or `nothing` for Base/Core/ExaModels, for
-# `Main`, and for anything else with no `Project.toml` behind it.  A module
-# whose entry point is not `<dir>/src/<Name>.jl` is an extension: its `pkgdir`
-# is already the parent's, so the parent's name and uuid are read from there.
+# `Main`, and for anything else with no `Project.toml` behind it.
 function _owning_package(m::Module)
     (m === Base || m === Core || m === ExaModels) && return nothing
     Base.moduleroot(m) === m || return nothing
@@ -744,12 +742,11 @@ function _owning_package(m::Module)
     id.uuid === nothing && return nothing              # Main, and other non-packages
     dir = pkgdir(m)
     dir === nothing && return nothing
-    path = Base.locate_package(id)
-    if path !== nothing &&
-       normpath(path) == normpath(joinpath(dir, "src", id.name * ".jl"))
-        return _Pkg(id.name, id.uuid, abspath(dir))
-    end
-    # An extension — take the package it belongs to.
+    # Read the name and uuid from the project rather than from the module's own
+    # `PkgId`: for an extension those differ, and `pkgdir` is already the parent
+    # package's directory, so this one path covers both.  An extension cannot be
+    # depended on by name, and does not need to be — importing the parent loads
+    # it, since ExaModels is imported too.
     for base in ("JuliaProject.toml", "Project.toml")
         proj = joinpath(dir, base)
         isfile(proj) || continue

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -215,8 +215,9 @@ function compile_library(
     trim::AbstractString = "safe",
     bundle::Bool = false,
     verbose::Bool = false,
+    argfun = nothing,
 )
-    spec = _model_spec(prefix, core, args)
+    spec = _model_spec(prefix, core, argfun, args)
     r = _compile([spec], out, prefix, trim, bundle, verbose)
     # One model keeps the singular field it has always returned.
     return (; libpath = r.libpath, outdir = r.outdir, prefix = spec.prefix)
@@ -280,7 +281,11 @@ end
 # values. Anything else is named precisely here — the pair spelling is easy to
 # get subtly wrong, and a mistake that reached `_model_spec` would be reported
 # as though the core itself were at fault.
-_core_and_args(::Symbol, core::ExaModels.ExaCore) = (core, ())
+# A pair cannot carry keywords, so an argument function is positional: it goes
+# SECOND, `:name => (core, argfun, example)`. Unambiguous because nothing
+# callable can ever be a model argument — the C boundary carries numbers,
+# arrays and tables, never a function.
+_core_and_args(::Symbol, core::ExaModels.ExaCore) = (core, nothing, ())
 function _core_and_args(name::Symbol, value::Tuple)
     isempty(value) && throw(
         ArgumentError(
@@ -293,7 +298,11 @@ function _core_and_args(name::Symbol, value::Tuple)
             "`:$name` must begin with an `ExaCore` — got a $(typeof(first(value))).",
         ),
     )
-    return (first(value), Base.tail(value))
+    rest = Base.tail(value)
+    if !isempty(rest) && first(rest) isa Function
+        return (first(value), first(rest), Base.tail(rest))
+    end
+    return (first(value), nothing, rest)
 end
 _core_and_args(name::Symbol, value) = throw(
     ArgumentError(
@@ -321,9 +330,33 @@ end
 # The per-model validation both entry points share. Everything here is checked
 # BEFORE any code generation, so a bad model is reported in the caller's process
 # rather than as a compile error in a generated file nobody is looking at.
-function _model_spec(prefix::AbstractString, core::ExaModels.ExaCore, args::Tuple)
+function _model_spec(prefix::AbstractString, core::ExaModels.ExaCore, argfun, args::Tuple)
     _check_prefix(prefix)
     core = _concretize(core)
+    if argfun !== nothing
+        # `args` are the example arguments to the FUNCTION, not to the core:
+        # the library carries the function, calls it at run time, and
+        # instantiates from whatever it returns. That is what lets a
+        # data-defined model be compiled once and instantiated at any data
+        # without a table crossing the boundary.
+        isempty(args) && throw(
+            ArgumentError(
+                "`$prefix`: `argfun` was given, so the examples are the " *
+                "arguments to call it with — e.g. `:$prefix => (core, " *
+                "ac_opf_args, \"case14.m\")`.",
+            ),
+        )
+        kind = _argfun_kind(prefix, args)
+        arg = argfun(args...)
+        arg isa Tuple || throw(
+            ArgumentError(
+                "`$prefix`: `argfun` must return the argument TUPLE the core is " *
+                "instantiated with — what you would splat into " *
+                "`ExaModel(core, ...)`. Got a $(typeof(arg)); wrap it, as `(data,)`.",
+            ),
+        )
+        return ModelSpec(String(prefix), core, arg, UserArgs{kind}(_argfun_call(prefix, argfun), argfun))
+    end
     if isempty(args)
         # No examples means a FIXED model: the core has no placeholders and is
         # compiled as-is. A core that declared placeholders cannot be meant —
@@ -714,8 +747,10 @@ Every package, other than ExaModels itself, that owns a type inside `core`.
 These become dependencies of the generated app *and* imports in its module, so
 that the serialized core can be read back there.
 """
-function _core_packages(core)
-    mods = _collect_modules!(Set{Module}(), Base.IdSet{Any}(), typeof(core))
+_core_packages(core) = _core_packages_of(typeof(core))
+
+function _core_packages_of(@nospecialize(T))
+    mods = _collect_modules!(Set{Module}(), Base.IdSet{Any}(), T)
     pkgs = _Pkg[]
     for m in sort!(collect(mods); by = string)
         p = _owning_package(m)
@@ -772,7 +807,15 @@ function _generate_app(specs::Vector{ModelSpec}, libname::AbstractString)
     # them must be a dependency and an import of the one generated app.
     pkgs = _Pkg[]
     for s in specs
-        for p in _core_packages(s.core)
+        # The core's own packages, plus — for a model with an argument
+        # function — the package that owns the function. That one must be
+        # IMPORTED, not merely pinned: the generated module calls it by name,
+        # so pinning it as a dependency leaves `ExaModelsPower.opf_args` a
+        # global of unknown type and `--trim=safe` refuses the call.
+        srcs = s.field isa UserArgs ?
+            (_core_packages(s.core)..., _core_packages_of(typeof(_argfun_of(s)))...) :
+            _core_packages(s.core)
+        for p in srcs
             any(q -> q.uuid == p.uuid, pkgs) || push!(pkgs, p)
         end
     end
@@ -824,6 +867,82 @@ end
 # consumer already speaks it, and a second ABI shape would buy nothing.
 struct FixedModel end
 
+# A user-supplied argument function, carried into the library and called at run
+# time. `K` is the shape of the one value that crosses the C boundary — `:str`
+# for `<prefix>_new_str(const char *)`, `:int` for `<prefix>_new(n)` — and
+# `call` is the function spelled as source, `Pkg.fun`.
+#
+# This is the third instantiation surface, and it composes with the builder
+# rather than competing: the builder passes structured data ACROSS the
+# boundary, this keeps the data on the far side and passes a path. A caller
+# holding tables wants the builder; a caller holding a filename wants this.
+#
+# The function is emitted BY NAME rather than serialized. A name is what
+# `juliac --trim=safe` resolves statically; a deserialized function object
+# would be a runtime value, and the call through it would not be.
+struct UserArgs{K}
+    call::String
+    fun::Any
+end
+
+# The function itself, for the package walk. Stored alongside the spelling
+# rather than re-resolved from it: `Pkg.fun` is a string by then.
+_argfun_of(s::ModelSpec) = s.field.fun
+
+# Which C entry point instantiates a model. Emitted for EVERY model, so a
+# consumer routes on it rather than probing for symbols.
+_argkind_value(::FixedModel) = 0            # `_new(n)`, `n` ignored
+_argkind_value(::Union{Nothing, Symbol}) = 1  # `_new(n)`, n is the size
+_argkind_value(::UserArgs{:int}) = 1        # `_new(n)`, n goes to the function
+_argkind_value(::UserArgs{:str}) = 2        # `_new_str(const char *)`
+_argkind_value(::BuilderModel) = 3          # `_data_begin` / `_new_from_data`
+
+_nargs_value(::UserArgs) = 1
+
+# One argument, because the scalar ABI carries one — a function of several is a
+# function of a tuple the caller builds, and there is nowhere on the boundary
+# to put the rest.
+function _argfun_kind(prefix, args)
+    length(args) == 1 || throw(
+        ArgumentError(
+            "`$prefix`: `argfun` is called with exactly one argument across the " *
+            "C boundary — got $(length(args)). Give it one value (a case file " *
+            "path, a size) and derive the rest inside the function.",
+        ),
+    )
+    a = only(args)
+    a isa AbstractString && return :str
+    a isa Integer && return :int
+    throw(
+        ArgumentError(
+            "`$prefix`: the example argument for `argfun` is a $(typeof(a)); the " *
+            "C boundary carries one string or one 64-bit integer. Anything " *
+            "richer belongs INSIDE the function — that is what it is for.",
+        ),
+    )
+end
+
+# `argfun` spelled as source. It must be a named function a package owns: the
+# generated library names it, so an anonymous function or a closure has nothing
+# to name, and would also defeat the static resolution above.
+function _argfun_call(prefix, f)
+    m = parentmodule(f)
+    n = nameof(f)
+    ok = try
+        isdefined(m, n) && getfield(m, n) === f && Base.moduleroot(m) === m
+    catch
+        false
+    end
+    ok || throw(
+        ArgumentError(
+            "`$prefix`: `argfun` must be a named function defined by a package — " *
+            "the generated library calls it by name. Got $(repr(f)) in module " *
+            "$m; define it at the top level of your package and pass that.",
+        ),
+    )
+    return string(nameof(m), ".", n)
+end
+
 @inline _nargs_count(::Val{N}) where {N} = N
 
 # How `rec_new(n)` turns its one integer into the argument the core expects —
@@ -857,6 +976,8 @@ function _instantiation_source(p::AbstractString, field::Union{Nothing, Symbol, 
         return Cint($(_nargs_value(field)))
     end
 
+$(_argkind_source(p, field))
+
     Base.@ccallable function $(p)_new(n::Cint)::Cint
         try
             push!(MODELS_$p, ExaModels.ExaModel(CORE_$p, $argexpr; check = Val(false)))
@@ -881,6 +1002,64 @@ end
 function _setter_arms(fields, render)
     isempty(fields) && return ""
     return join((render(f) for f in fields), "") * "\n"
+end
+
+# `_argkind` is emitted for every model, whatever its surface: `_nargs` says
+# how many values are needed and cannot say what SHAPE they are, and a consumer
+# handed only a library path needs both. Routing on it beats probing for
+# symbols, which is what a consumer had to do before.
+_argkind_source(p::AbstractString, field) = """
+    # Which entry point instantiates this model: 0 fixed, 1 `$(p)_new(n)`,
+    # 2 `$(p)_new_str(const char *)`, 3 the `$(p)_data_begin` builder.
+    Base.@ccallable function $(p)_argkind()::Cint
+        return Cint($(_argkind_value(field)))
+    end
+"""
+
+# The argument-function surface. `unsafe_string` copies out of the caller's
+# buffer, so the library never holds a pointer it does not own.
+function _instantiation_source(p::AbstractString, u::UserArgs{:str})
+    return """
+    Base.@ccallable function $(p)_nargs()::Cint
+        return Cint(1)
+    end
+
+$(_argkind_source(p, u))
+    # This model instantiates from a string; `$(p)_new(n)` is not its entry
+    # point, so it returns the documented failure value rather than building
+    # something.
+    Base.@ccallable function $(p)_new(n::Cint)::Cint
+        return Cint(0)
+    end
+
+    Base.@ccallable function $(p)_new_str(s_ptr::Ptr{Cchar})::Cint
+        try
+            s = unsafe_string(s_ptr)
+            push!(MODELS_$p, ExaModels.ExaModel(CORE_$p, $(u.call)(s)...; check = Val(false)))
+            return Cint(length(MODELS_$p))
+        catch
+            return Cint(0)
+        end
+    end
+"""
+end
+
+function _instantiation_source(p::AbstractString, u::UserArgs{:int})
+    return """
+    Base.@ccallable function $(p)_nargs()::Cint
+        return Cint(1)
+    end
+
+$(_argkind_source(p, u))
+    Base.@ccallable function $(p)_new(n::Cint)::Cint
+        try
+            push!(MODELS_$p, ExaModels.ExaModel(CORE_$p, $(u.call)(Int(n))...; check = Val(false)))
+            return Cint(length(MODELS_$p))
+        catch
+            return Cint(0)
+        end
+    end
+"""
 end
 
 function _instantiation_source(p::AbstractString, bm::BuilderModel)
@@ -943,6 +1122,7 @@ function _instantiation_source(p::AbstractString, bm::BuilderModel)
     )
 
     return """
+$(_argkind_source(p, bm))
     # ── builder for `$p` (schema + typed setters, ABI v2) ────────────────────
 
     const SCHEMA_$p = Vector{UInt8}($(repr(json)))
@@ -1107,7 +1287,7 @@ function _model_source(s::ModelSpec)
     p = s.prefix
     # A builder spec's example is the whole tuple of values, splatted back the
     # way `ExaModel` takes them; the other forms carry a single value.
-    example = s.field isa BuilderModel ? "ARG0_$p..." : "ARG0_$p"
+    example = (s.field isa BuilderModel || s.field isa UserArgs) ? "ARG0_$p..." : "ARG0_$p"
     return """
     # ── model `$p` ───────────────────────────────────────────────────────────
 

--- a/ExaModelsC/src/ExaModelsC.jl
+++ b/ExaModelsC/src/ExaModelsC.jl
@@ -217,7 +217,12 @@ return the argument TUPLE the core is instantiated with.  The example is
 
 Every model also exports `P_argkind() -> 0 | 1 | 2 | 3` (fixed, `P_new(n)`,
 `P_new_str`, builder), so a consumer routes on the declared shape instead
-of probing for symbols.
+of probing for symbols.  Kind 1 covers both n-is-the-size and
+n-goes-to-an-argument-function: the two are indistinguishable to a consumer
+**by design** — the call shape is identical, and what the library does with
+`n` is its own business.  `P_nargs` says how MANY values instantiation
+takes and cannot say what shape they are; `P_argkind` is the other half of
+that pair, and a consumer handed only a library path needs both.
 
 ## Several models in one library
 

--- a/ExaModelsC/test/builder_check.py
+++ b/ExaModelsC/test/builder_check.py
@@ -1,0 +1,31 @@
+# Drives the schema + builder ABI of a compiled structured model from Python:
+# positional values against the schema's field order, the table as a dict of
+# columns. Inputs mirror the S_* constants in runtests.jl — keep them in sync.
+#
+# usage: python builder_check.py <libpath> <prefix> <n> <outfile>
+import sys
+
+import numpy as np
+
+import cnlpmodels
+
+libpath, prefix, n, outfile = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
+
+lib = cnlpmodels.load(libpath)
+v0 = np.linspace(0.1, 0.6, n)
+lo = np.full(n, -5.0)
+tab = {
+    "i": np.array([2, 5, 6]),
+    "w": np.array([1.5, 3.0, 0.5]),
+    "s": np.array([2.0, -1.0, 0.0]),
+}
+
+m = cnlpmodels.CModel(lib, n, v0, lo, tab, prefix=prefix)
+x = np.linspace(0.5, 3.0, n)
+
+with open(outfile, "w") as f:
+    f.write("nvar %d\n" % m.nvar)
+    f.write("ncon %d\n" % m.ncon)
+    f.write("obj %.17g\n" % m.obj(x))
+    f.write("grad " + " ".join("%.17g" % v for v in m.grad(x)) + "\n")
+    f.write("cons " + " ".join("%.17g" % v for v in m.cons(x)) + "\n")

--- a/ExaModelsC/test/fixtures/RecipeKernels/ext/RecipeKernelsExaModels.jl
+++ b/ExaModelsC/test/fixtures/RecipeKernels/ext/RecipeKernelsExaModels.jl
@@ -7,4 +7,9 @@ import RecipeKernels
 built with it names a module that cannot be a dependency of anything."
 @inline ramp(i) = 0.25 * i
 
+"""A tuple-returning argument function owned by the EXTENSION, for the argfun
+guard test: it must get past the tuple-return check so the guard itself is what
+refuses it."""
+exttables(n) = (Int(n),)
+
 end # module

--- a/ExaModelsC/test/fixtures/RecipeKernels/src/RecipeKernels.jl
+++ b/ExaModelsC/test/fixtures/RecipeKernels/src/RecipeKernels.jl
@@ -16,7 +16,7 @@ recompiles, whereas a closure carries a gensym that is not.
 """
 module RecipeKernels
 
-export alternating, offsets, doubled_args, parsed_args
+export alternating, offsets, doubled_args, parsed_args, table2d, datant
 
 "Alternating starting point — the shape a per-index start generator takes."
 @inline alternating(i) = isodd(i) ? -1.2 : 1.0
@@ -35,5 +35,20 @@ doubled_args(n::Integer) = (2 * Int(n),)
 "The string-kind argument function: `P_new_str(s)` hands the string to it —
 standing in for a case-file path parsed on the far side of the boundary."
 parsed_args(s::AbstractString) = (parse(Int, s),)
+
+"A 2-D table of heterogeneous tuples over an open size — the COPS-shaped
+deferred data (a Matrix of (Int,Int,Int,F64,F64,F64) rows over `1:n × 1:3`)
+that exercises product iterators and per-element instantiate typing."
+table2d(n) = [(i, j, i + j, 0.5, 1.5, 2.5) for i in 1:n, j in 1:3]
+
+"A NamedTuple-returning data function — the shape a modelling library's
+`*_data(n)` takes, with fields PROJECTED out of the deferred call
+(`d.v_start` for starts, `d.tab` as an iterator): the projections are
+`ArgIndexed` nodes over the one `ArgNode1`, which is the structure the
+gasoil-class cores carry."
+datant(n) = (
+    v_start = fill(0.5, 3 * n),
+    tab = [(i, j, 0.5 + i) for i in 1:n, j in 1:3],
+)
 
 end # module

--- a/ExaModelsC/test/fixtures/RecipeKernels/src/RecipeKernels.jl
+++ b/ExaModelsC/test/fixtures/RecipeKernels/src/RecipeKernels.jl
@@ -16,7 +16,7 @@ recompiles, whereas a closure carries a gensym that is not.
 """
 module RecipeKernels
 
-export alternating, offsets
+export alternating, offsets, doubled_args, parsed_args
 
 "Alternating starting point — the shape a per-index start generator takes."
 @inline alternating(i) = isodd(i) ? -1.2 : 1.0
@@ -24,5 +24,16 @@ export alternating, offsets
 "An index set computed from the size: a comprehension, so it has no symbolic
 form and has to run once the size is known."
 offsets(n) = [2 * div(i - 1, 2) for i in 1:2:max(n - 2, 0)]
+
+# Argument functions for the argfun surface: named, package-owned, returning
+# the argument TUPLE the core is instantiated with — the contract
+# `compile_library` requires so the generated library can call them by name.
+
+"The integer-kind argument function: `P_new(n)` hands `n` to it."
+doubled_args(n::Integer) = (2 * Int(n),)
+
+"The string-kind argument function: `P_new_str(s)` hands the string to it —
+standing in for a case-file path parsed on the far side of the boundary."
+parsed_args(s::AbstractString) = (parse(Int, s),)
 
 end # module

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -87,7 +87,7 @@ function runtests()
             ntsrc = ExaModelsC._module_source("M", [s])
             @test occursin("(; N = Int(n))", ntsrc)
             @test occursin("nt_new(", ntsrc)
-            @test !occursin("nt_data_begin", ntsrc)
+            @test !occursin("function nt_data_begin", ntsrc)   # the comment may NAME it
 
             # Anything else flattens to the builder: bare values by position,
             # NamedTuple entries by key, and NO `P_new` — the surfaces are
@@ -98,7 +98,7 @@ function runtests()
             @test b.field isa ExaModelsC.BuilderModel
             @test [f.name for f in b.field.fields] == ["arg1", "v0", "lo", "arg3"]
             bsrc = ExaModelsC._module_source("M", [b])
-            @test !occursin("bs_new(", bsrc)
+            @test !occursin("function bs_new(", bsrc)   # `_argkind`'s comment names it
             for sym in (
                 "bs_schema", "bs_data_begin", "bs_set_scalar_i64",
                 "bs_set_scalar_f64", "bs_set_array_i64", "bs_set_array_f64",
@@ -475,16 +475,40 @@ function runtests()
             @test_throws MethodError compile_library(OUT, :a => (c, 4); prefix = "z")
         end
 
+        @testset "an argument function is checked before it is compiled" begin
+            c = build()
+            # Examples are the FUNCTION's arguments; none means nothing to pin.
+            @test_throws "the examples are the arguments" compile_library(
+                OUT, c; argfun = RecipeKernels.doubled_args)
+            # One value crosses the boundary; give the function one.
+            @test_throws "exactly one argument" compile_library(
+                OUT, c, 4, 5; argfun = RecipeKernels.doubled_args)
+            # A float is neither of the two shapes the boundary carries.
+            @test_throws "one string or one 64-bit integer" compile_library(
+                OUT, c, 1.5; argfun = RecipeKernels.doubled_args)
+            # The function must return the argument tuple the core takes.
+            @test_throws "must return the argument TUPLE" compile_library(
+                OUT, c, 4; argfun = RecipeKernels.alternating)
+            # Anonymous functions have no name for the library to call.
+            @test_throws "named function" compile_library(OUT, c, 4; argfun = n -> (n,))
+            # The pair spelling: a Function in second position is the argfun —
+            # nothing callable can ever be a model argument.
+            co, fn, rest = ExaModelsC._core_and_args(:m, (c, RecipeKernels.doubled_args, 4))
+            @test fn === RecipeKernels.doubled_args && rest == (4,)
+        end
+
         @testset "a structured model instantiates through the builder" begin
-            # One compile carries BOTH surfaces — the builder model and a
-            # one-knob model in one library: the surface is per prefix, not
-            # per file.
+            # One compile carries every surface — builder, one-knob, and both
+            # argument-function kinds — in one library: the surface is per
+            # prefix, not per file.
             sb = compile_library(
                 joinpath(OUT, "structs"),
                 :structm => (sbuild(), S_EXARGS...),
                 :knob => (build(), 4),
+                :dbl => (build(), RecipeKernels.doubled_args, 4),
+                :strd => (build(), RecipeKernels.parsed_args, "6"),
             )
-            @test sb.prefixes == ["structm", "knob"]
+            @test sb.prefixes == ["structm", "knob", "dbl", "strd"]
             slib = CNLPModels.load(sb.libpath)
 
             # The builder model exports no one-integer constructor; the knob
@@ -534,6 +558,23 @@ function runtests()
             @test NLPModels.obj(m, x) ≈ NLPModels.obj(ref, x)
             k = CNLPModels.CNLPModel(slib, 7; prefix = "knob")
             @test k.meta.nvar == 7
+
+            # The third surface: argument functions of both kinds, in the same
+            # library. `_argkind` declares every model's shape — 0 fixed,
+            # 1 `_new(n)`, 2 `_new_str`, 3 builder — so a consumer routes on
+            # it rather than probing symbols.
+            ak(s) = ccall(dl(Symbol(s, :_argkind)), Cint, ())
+            @test ak("knob") == 1 && ak("structm") == 3
+            @test ak("dbl") == 1 && ak("strd") == 2
+            # :int kind — `P_new(n)` hands n to the function (size 2n here).
+            dm = CNLPModels.CNLPModel(slib, 5; prefix = "dbl")
+            @test dm.meta.nvar == 10
+            # :str kind — `P_new_str` instantiates; `P_new` is not its entry
+            # point and returns the documented failure value.
+            sid = ccall(dl(:strd_new_str), Cint, (Cstring,), "6")
+            @test sid > 0
+            @test ccall(dl(:strd_nvar), Cint, (Cint,), sid) == 6
+            @test ccall(dl(:strd_new), Cint, (Cint,), 4) == 0
 
             # Wrong-arity and incomplete data are the consumer's errors, not
             # aborts: the library reports, the consumer explains.

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -503,8 +503,19 @@ function runtests()
             # getglobal(Main, ...) verifier errors after minutes of juliac.
             # (Defined at the top of this file: evaluating it here would leave
             # it too new for the probe call that precedes the guard.)
-            @test_throws "defined in a script or the REPL" compile_library(
+            @test_throws "defined in a script" compile_library(
                 OUT, c, 4; argfun = Main.script_argfun)
+
+            # An EXTENSION-owned function passes every root-module predicate —
+            # an extension is its own moduleroot, and `_owning_package` maps it
+            # to its parent — but the generated app imports only packages, so
+            # `RecipeKernelsExaModels.exttables` would be an UndefVarError
+            # inside generated code.  The guard must refuse it up front, with
+            # the move-to-the-parent advice.
+            ext = Base.get_extension(RecipeKernels, :RecipeKernelsExaModels)
+            @test ext !== nothing
+            @test_throws "package extension" compile_library(
+                OUT, c, 4; argfun = ext.exttables)
             # The pair spelling: a Function in second position is the argfun —
             # nothing callable can ever be a model argument.
             co, fn, rest = ExaModelsC._core_and_args(:m, (c, RecipeKernels.doubled_args, 4))

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -28,18 +28,85 @@ end
 
 const OUT = get(ENV, "EXAMODELSC_TEST_OUT", joinpath(tempdir(), "examodelsc_test"))
 
+# A three-placeholder recipe — a bare size, a NamedTuple carrying a start and
+# a bound, and a table — the data-defined shape the builder ABI exists for.
+function sbuild()
+    c, sz, dat, tab = ExaCore(nargs = Val(3))
+    @add_var(c, x, sz; start = dat.v0, lvar = dat.lo)
+    @add_obj(c, t.w * (x[t.i] - t.s)^2 for t in tab)
+    @add_con(c, x[i] + x[i+1] for i in 1:(sz - 1); lcon = -100.0, ucon = 100.0)
+    return c
+end
+
+# The example values `sbuild` is compiled against, and the instantiation data
+# the compile never sees (different size, different rows).
+const S_EXTAB = [(i = 1, w = 2.0, s = 1.0), (i = 3, w = 1.0, s = 0.5)]
+const S_EXARGS = (4, (v0 = fill(0.5, 4), lo = fill(-10.0, 4)), S_EXTAB)
+const S_N = 6
+const S_V0 = collect(range(0.1, 0.6; length = S_N))
+const S_LO = fill(-5.0, S_N)
+const S_TAB = [(i = 2, w = 1.5, s = 2.0), (i = 5, w = 3.0, s = -1.0), (i = 6, w = 0.5, s = 0.0)]
+
 function runtests()
     @testset "ExaModelsC" begin
 
         @testset "the example arg is read, not guessed" begin
             c = build()
-            # A shape `P_new(n)` cannot carry must be refused up front, with a
-            # reason — not discovered as a missing symbol at load time.
+            # `build`'s core reads its one placeholder as a bare size, so a
+            # NamedTuple example cannot instantiate it — refused up front by
+            # the probe, with a reason, not discovered inside juliac.
             @test_throws ArgumentError compile_library(OUT, c, (N = 4, v = [1.0]))
             @test_throws ArgumentError compile_library(OUT, c, (x = 1.5,))
             # And a prefix that is not a C identifier is caught before juliac.
             @test_throws ArgumentError compile_library(OUT, c, 4; prefix = "lib-a")
             @test_throws ArgumentError compile_library(OUT, c, 4; prefix = "2fast")
+        end
+
+        @testset "builder examples are read, not guessed" begin
+            c = build()
+            # Types that cannot cross the boundary stay refused with the
+            # builder there.
+            @test_throws ArgumentError compile_library(OUT, c, "c")
+            @test_throws ArgumentError compile_library(OUT, c, 4, "c", [1.0, 2.0])
+            # Builder storage is the example's type EXACTLY — looser numeric
+            # types are named here, not discovered inside the compiled library.
+            @test_throws "Int64/Float64" compile_library(OUT, c, Int32(4), [1.0])
+            @test_throws "Int64/Float64" compile_library(OUT, c, 4, Float32[1.0])
+            @test_throws "Int64/Float64" compile_library(OUT, c, 4, 1:3)
+            # Flattened field names must be distinct across all placeholders.
+            @test_throws "both be named" compile_library(OUT, c, (n = 1,), (n = 2.0,))
+            # An empty example, and rows with no columns, carry no types.
+            @test_throws ArgumentError compile_library(OUT, c, [1.0], Float64[])
+            @test_throws "no columns" compile_library(OUT, c, [1.0], [(;), (;)])
+
+            # A one-key integer NamedTuple keeps the `P_new(n)` fast path —
+            # the generated constructor rebuilds the key.
+            cnt, _ = ExaCore(nargs = Val(1))
+            s = ExaModelsC._model_spec("nt", cnt, ((N = 4,),))
+            @test s.field === :N
+            ntsrc = ExaModelsC._module_source("M", [s])
+            @test occursin("(; N = Int(n))", ntsrc)
+            @test occursin("nt_new(", ntsrc)
+            @test !occursin("nt_data_begin", ntsrc)
+
+            # Anything else flattens to the builder: bare values by position,
+            # NamedTuple entries by key, and NO `P_new` — the surfaces are
+            # disjoint, which is how a consumer routes a lone integer.
+            b = ExaModelsC._model_spec(
+                "bs", cnt, (4, (v0 = [1.0], lo = [2.0]), [(i = 1, w = 0.5)]),
+            )
+            @test b.field isa ExaModelsC.BuilderModel
+            @test [f.name for f in b.field.fields] == ["arg1", "v0", "lo", "arg3"]
+            bsrc = ExaModelsC._module_source("M", [b])
+            @test !occursin("bs_new(", bsrc)
+            for sym in (
+                "bs_schema", "bs_data_begin", "bs_set_scalar_i64",
+                "bs_set_scalar_f64", "bs_set_array_i64", "bs_set_array_f64",
+                "bs_set_col_i64", "bs_set_col_f64", "bs_data_ready",
+                "bs_new_from_data", "bs_nargs",
+            )
+                @test occursin(sym, bsrc)
+            end
         end
 
         @testset "a recipe's own package travels into the generated app" begin
@@ -380,14 +447,88 @@ function runtests()
             @test_throws "both named `a`" compile_library(OUT, :a => (c, 4), :a => (c, 5))
             @test_throws "must be a C identifier" compile_library(
                 OUT, Symbol("2bad") => (c, 4))
-            # The per-model restrictions are the single-model ones, and the
-            # message names which model is at fault.
-            @test_throws "`b`: this recipe needs the schema" compile_library(
+            # The per-model checks are the single-model ones, and the message
+            # names which model is at fault: two bare integers flatten to a
+            # perfectly valid two-field schema, but this core declared ONE
+            # placeholder, so the probe refuses before juliac spends minutes.
+            @test_throws "`b`: the example values do not instantiate" compile_library(
                 OUT, :a => (c, 4), :b => (c, 4, 5))
             @test_throws "`b`: this core declared 1 placeholder" compile_library(
                 OUT, :a => (c, 4), :b => c)
             # `prefix =` has no meaning when the names supply the prefixes.
             @test_throws MethodError compile_library(OUT, :a => (c, 4); prefix = "z")
+        end
+
+        @testset "a structured model instantiates through the builder" begin
+            # One compile carries BOTH surfaces — the builder model and a
+            # one-knob model in one library: the surface is per prefix, not
+            # per file.
+            sb = compile_library(
+                joinpath(OUT, "structs"),
+                :structm => (sbuild(), S_EXARGS...),
+                :knob => (build(), 4),
+            )
+            @test sb.prefixes == ["structm", "knob"]
+            slib = CNLPModels.load(sb.libpath)
+
+            # The builder model exports no one-integer constructor; the knob
+            # model exports no builder. Disjoint, as the consumers assume.
+            dl(s) = CNLPModels.Libdl.dlsym(slib.handle, s; throw_error = false)
+            @test dl(:structm_new) === nothing
+            @test dl(:structm_data_begin) !== nothing
+            @test dl(:knob_new) !== nothing
+            @test dl(:knob_data_begin) === nothing
+            @test ccall(dl(:structm_nargs), Cint, ()) == 4
+
+            # The published schema is the flattened example: bare values by
+            # position, NamedTuple entries by key, the table with its columns.
+            sj = CNLPModels.schema_json(slib; prefix = "structm")
+            for needle in (
+                "\"arg1\"", "\"v0\"", "\"lo\"",
+                """{"name":"arg3","kind":"table","columns":[{"name":"i","type":"i64"},{"name":"w","type":"f64"},{"name":"s","type":"f64"}]}""",
+            )
+                @test occursin(needle, sj)
+            end
+
+            # Instantiated at a size and data the compile never saw, through
+            # the consumer's positional spelling — one value per schema field.
+            m = CNLPModels.CNLPModel(slib, S_N, S_V0, S_LO, S_TAB; prefix = "structm")
+            ref = ExaModel(sbuild(), S_N, (v0 = S_V0, lo = S_LO), S_TAB)
+
+            @test m.meta.nvar == ref.meta.nvar == S_N
+            @test m.meta.ncon == ref.meta.ncon == S_N - 1
+            @test m.meta.x0 ≈ ref.meta.x0
+            @test m.meta.lvar ≈ ref.meta.lvar
+
+            x = collect(range(0.5, 3.0; length = S_N))
+            y = collect(range(-1.0, 1.0; length = S_N - 1))
+            @test NLPModels.obj(m, x) ≈ NLPModels.obj(ref, x)
+            @test NLPModels.grad(m, x) ≈ NLPModels.grad(ref, x)
+            @test NLPModels.cons(m, x) ≈ NLPModels.cons(ref, x)
+            @test NLPModels.jac_coord(m, x) ≈ NLPModels.jac_coord(ref, x)
+            @test NLPModels.hess_coord(m, x, y; obj_weight = 0.5) ≈
+                  NLPModels.hess_coord(ref, x, y; obj_weight = 0.5)
+
+            # A second builder instance and the sibling knob model, with the
+            # first instance undisturbed.
+            m2 = CNLPModels.CNLPModel(
+                slib, 4, fill(0.5, 4), fill(-10.0, 4), S_EXTAB; prefix = "structm",
+            )
+            @test m2.meta.nvar == 4
+            @test NLPModels.obj(m, x) ≈ NLPModels.obj(ref, x)
+            k = CNLPModels.CNLPModel(slib, 7; prefix = "knob")
+            @test k.meta.nvar == 7
+
+            # Wrong-arity and incomplete data are the consumer's errors, not
+            # aborts: the library reports, the consumer explains.
+            @test_throws ErrorException CNLPModels.CNLPModel(
+                slib, S_N, S_V0; prefix = "structm")
+
+            # And a solve through the builder-instantiated model.
+            res = NLPModelsIpopt.ipopt(m; print_level = 0)
+            refres = NLPModelsIpopt.ipopt(ref; print_level = 0)
+            @test res.status == refres.status
+            @test res.objective ≈ refres.objective atol = 1e-6
         end
 
         @testset "the Python consumer reads the same model" begin
@@ -464,6 +605,54 @@ function runtests()
                 @test Int.(vals["hess_cols"]) == hc
                 @test vals["hess"] ≈ NLPModels.hess_coord(ref, x, y; obj_weight = 0.5)
                 end
+            end
+        end
+
+        @testset "the Python consumer drives the builder" begin
+            # Same probing as the leg above; additionally needs the structured
+            # library the builder testset compiled.
+            pysrc = get(
+                ENV, "CNLPMODELS_PY",
+                joinpath(homedir(), "git", "pkg", "cnlpmodels-py", "src"),
+            )
+            py = nothing
+            for cand in ("python3", "python")
+                ok = try
+                    success(pipeline(`$cand -c "import numpy"`; stdout = devnull, stderr = devnull))
+                catch
+                    false
+                end
+                ok && (py = cand; break)
+            end
+            slibpath = joinpath(
+                OUT, "structs", "libstructs." * Base.BinaryPlatforms.platform_dlext(),
+            )
+            if py === nothing || !isdir(pysrc) || !isfile(slibpath)
+                @info "skipping the Python builder leg" python = py lib = isfile(slibpath)
+                @test_skip false
+            else
+                script = joinpath(@__DIR__, "builder_check.py")
+                outfile = joinpath(mktempdir(), "py.txt")
+                env = copy(ENV)
+                sep = Sys.iswindows() ? ";" : ":"
+                env["PYTHONPATH"] =
+                    pysrc * (haskey(env, "PYTHONPATH") ? sep * env["PYTHONPATH"] : "")
+                run(setenv(`$py $script $slibpath structm $S_N $outfile`, env))
+
+                vals = Dict{String,Vector{Float64}}()
+                for line in eachline(outfile)
+                    parts = split(line)
+                    vals[parts[1]] = parse.(Float64, parts[2:end])
+                end
+                # The script's inputs mirror S_V0/S_LO/S_TAB — the reference
+                # is the same in-Julia model the in-process leg checked.
+                ref = ExaModel(sbuild(), S_N, (v0 = S_V0, lo = S_LO), S_TAB)
+                x = collect(range(0.5, 3.0; length = S_N))
+                @test only(vals["nvar"]) == ref.meta.nvar
+                @test only(vals["ncon"]) == ref.meta.ncon
+                @test only(vals["obj"]) ≈ NLPModels.obj(ref, x)
+                @test vals["grad"] ≈ NLPModels.grad(ref, x)
+                @test vals["cons"] ≈ NLPModels.cons(ref, x)
             end
         end
 

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -132,6 +132,22 @@ function runtests()
             @add_obj(plain, (z[i] - 2.0)^2 for i in 1:M)
             @test isempty(ExaModelsC._core_packages(ExaModelsC._concretize(plain)))
 
+            # A package the CALLER is developing — RecipeKernels is path-
+            # tracked in this test environment — is pinned in the generated
+            # project as a dependency + path source even when no core
+            # references it, so the app compiles the code the caller is
+            # actually running rather than the registry copy. It is NOT
+            # imported: only a core's own packages need that.
+            @test any(p -> p.name == "RecipeKernels", ExaModelsC._developed_packages())
+            pdir = ExaModelsC._generate_app(
+                [ExaModelsC._model_spec("pl", ExaModelsC._concretize(plain), (4,))],
+                "pl",
+            )
+            pproj = read(joinpath(pdir, "Project.toml"), String)
+            psrc = read(joinpath(pdir, "src", "ExaLib_pl.jl"), String)
+            @test occursin("RecipeKernels = {path =", pproj)
+            @test !occursin("import RecipeKernels", psrc)
+
             # Both halves are needed and neither alone is enough: a dependency
             # the app never imports resolves no better than one it never had, so
             # the generated files are checked for the dependency AND the import.

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -69,7 +69,7 @@ function runtests()
             # the app never imports resolves no better than one it never had, so
             # the generated files are checked for the dependency AND the import.
             appdir = ExaModelsC._generate_app(
-                ExaModelsC._concretize(c), 8, nothing, "rk",
+                [ExaModelsC._model_spec("rk", ExaModelsC._concretize(c), (8,))], "rk",
             )
             proj = read(joinpath(appdir, "Project.toml"), String)
             src = read(joinpath(appdir, "src", "ExaLib_rk.jl"), String)
@@ -87,7 +87,7 @@ function runtests()
                 import Pkg
                 Pkg.instantiate(; io = devnull)
                 import ExaModels, Serialization, RecipeKernels
-                core = Serialization.deserialize(joinpath(@__DIR__, "src", "core.jls"))
+                core = Serialization.deserialize(joinpath(@__DIR__, "src", "core_rk.jls"))
                 m = ExaModels.ExaModel(core, 12; check = Val(false))
                 write(
                     joinpath(@__DIR__, "answer.txt"),
@@ -294,6 +294,100 @@ function runtests()
                 # The Python leg below is the consumer for this form here.
                 @info "in-process unbundled loading is Linux-only; skipped"
             end
+        end
+
+        @testset "several models in one library" begin
+            # One library carrying three models: the same recipe under two
+            # names — so the two are known to be genuinely separate, not one
+            # model aliased twice — and a fixed model taking no instantiation
+            # data at all.  Compiling takes minutes, so this is the suite's
+            # only multi-model build.
+            n = 5
+            fc = ExaCore()
+            @add_var(fc, z, n; start = 1.0)
+            @add_obj(fc, (z[i] - 4.0)^2 for i in 1:n)
+            fref = ExaModel(fc)
+
+            g = compile_library(
+                joinpath(OUT, "grid"),
+                :sized => (build(), 4),
+                :other => (build(), 6),
+                :flat => fc,
+            )
+
+            @test g.prefixes == ["sized", "other", "flat"]
+            @test isfile(g.libpath)
+            # The FILE is named after `out`, not after any one model. This is
+            # what separates one multi-model library from three single-model
+            # ones, and it is what a consumer resolves `@grid` against.
+            @test basename(g.libpath) ==
+                  "libgrid." * Base.BinaryPlatforms.platform_dlext()
+
+            glib = CNLPModels.load(g.libpath)
+
+            # Each model declares its own arity, out of the one library.
+            @test ccall(
+                CNLPModels.Libdl.dlsym(glib.handle, :sized_nargs), Cint, ()) == 1
+            @test ccall(
+                CNLPModels.Libdl.dlsym(glib.handle, :other_nargs), Cint, ()) == 1
+            @test ccall(
+                CNLPModels.Libdl.dlsym(glib.handle, :flat_nargs), Cint, ()) == 0
+
+            # Instances of three different models, from one library, at once —
+            # and at sizes neither compile saw (the examples were 4 and 6).
+            a = CNLPModels.CNLPModel(glib, 9; prefix = "sized")
+            b = CNLPModels.CNLPModel(glib, 13; prefix = "other")
+            c = CNLPModels.CNLPModel(glib; prefix = "flat")
+            @test a.meta.nvar == 9
+            @test b.meta.nvar == 13
+            @test c.meta.nvar == n
+
+            # Separate instance tables, not one shared counter: each model's
+            # first instance is id 1.  Sharing a table would number these
+            # 1, 2, 3, so this is what actually distinguishes the two designs.
+            @test a.id == b.id == c.id == 1
+
+            # And no model's instantiation disturbed another's.
+            @test NLPModels.obj(a, fill(1.0, 9)) ≈ 9.0
+            @test NLPModels.obj(b, fill(1.0, 13)) ≈ 13.0
+            @test NLPModels.obj(c, fill(1.0, n)) ≈ NLPModels.obj(fref, fill(1.0, n))
+
+            # Each still evaluates as its own core, against an in-Julia
+            # reference — the derivatives too, not just the sizes.
+            aref = ExaModel(build(), 9)
+            x = collect(range(0.5, 3.0; length = 9))
+            y = collect(range(-1.0, 1.0; length = 8))
+            @test NLPModels.obj(a, x) ≈ NLPModels.obj(aref, x)
+            @test NLPModels.grad(a, x) ≈ NLPModels.grad(aref, x)
+            @test NLPModels.cons(a, x) ≈ NLPModels.cons(aref, x)
+            @test NLPModels.jac_coord(a, x) ≈ NLPModels.jac_coord(aref, x)
+            @test NLPModels.hess_coord(a, x, y; obj_weight = 0.5) ≈
+                  NLPModels.hess_coord(aref, x, y; obj_weight = 0.5)
+
+            # The consumer's own spelling for this selection is
+            # `CNLPModel(glib, :sized, 9)` — the same prefix, named as a
+            # symbol; it is exercised in CNLPModels' own suite.
+        end
+
+        @testset "a multi-model library is checked before it is compiled" begin
+            # Every one of these is refused in this process, before any code is
+            # generated and long before juliac runs.
+            c = build()
+            @test_throws ArgumentError compile_library(OUT)          # no models
+            @test_throws "is not a model" compile_library(OUT, :a => 5)
+            @test_throws "names no core" compile_library(OUT, :a => ())
+            @test_throws "must begin with an `ExaCore`" compile_library(OUT, :a => (4, c))
+            @test_throws "both named `a`" compile_library(OUT, :a => (c, 4), :a => (c, 5))
+            @test_throws "must be a C identifier" compile_library(
+                OUT, Symbol("2bad") => (c, 4))
+            # The per-model restrictions are the single-model ones, and the
+            # message names which model is at fault.
+            @test_throws "`b`: this recipe needs the schema" compile_library(
+                OUT, :a => (c, 4), :b => (c, 4, 5))
+            @test_throws "`b`: this core declared 1 placeholder" compile_library(
+                OUT, :a => (c, 4), :b => c)
+            # `prefix =` has no meaning when the names supply the prefixes.
+            @test_throws MethodError compile_library(OUT, :a => (c, 4); prefix = "z")
         end
 
         @testset "the Python consumer reads the same model" begin

--- a/ExaModelsC/test/runtests.jl
+++ b/ExaModelsC/test/runtests.jl
@@ -28,6 +28,11 @@ end
 
 const OUT = get(ENV, "EXAMODELSC_TEST_OUT", joinpath(tempdir(), "examodelsc_test"))
 
+# A NAMED function in Main, for the argfun guard test: Main is its own
+# moduleroot, so only the package-ownership check refuses it. Defined here so
+# the world has advanced by the time the guard's preceding probe calls it.
+Main.eval(:(script_argfun(n) = (Int(n),)))
+
 # A three-placeholder recipe — a bare size, a NamedTuple carrying a start and
 # a bound, and a table — the data-defined shape the builder ABI exists for.
 function sbuild()
@@ -491,6 +496,15 @@ function runtests()
                 OUT, c, 4; argfun = RecipeKernels.alternating)
             # Anonymous functions have no name for the library to call.
             @test_throws "named function" compile_library(OUT, c, 4; argfun = n -> (n,))
+            # A NAMED function in Main is its own moduleroot and used to pass
+            # the guard — but the generated app calls the function by name
+            # from another process, so nothing outside a package is reachable.
+            # Before the guard learned this, it surfaced as unresolved
+            # getglobal(Main, ...) verifier errors after minutes of juliac.
+            # (Defined at the top of this file: evaluating it here would leave
+            # it too new for the probe call that precedes the guard.)
+            @test_throws "defined in a script or the REPL" compile_library(
+                OUT, c, 4; argfun = Main.script_argfun)
             # The pair spelling: a Function in second position is the argfun —
             # nothing callable can ever be a model argument.
             co, fn, rest = ExaModelsC._core_and_args(:m, (c, RecipeKernels.doubled_args, 4))

--- a/src/argument.jl
+++ b/src/argument.jl
@@ -209,10 +209,15 @@ true
 # (Julia's passthrough heuristic), and the `map` below then carries a dynamic
 # call that `juliac --trim=safe` cannot resolve. Harmless under the JIT,
 # load-bearing for AOT — same reason on the `ExaCore` method in nlp.jl.
-@inline instantiate(t::Tuple, a::Vararg{Any,N}) where {N} =
-    map(x -> instantiate(x, a...), t)
-@inline instantiate(t::NamedTuple, a::Vararg{Any,N}) where {N} =
-    map(x -> instantiate(x, a...), t)
+# EXPERIMENT (Ohm): unrolled as well as specialized. #308's `Vararg{Any,N}`
+# is necessary — without it the vararg is not specialized at all — but on a
+# core the size of an AC OPF's the `map` closure is still unresolved.
+@inline _instantiate_all(a::Tuple) = ()
+@inline _instantiate_all(a::Tuple, x, xs...) =
+    (instantiate(x, a...), _instantiate_all(a, xs...)...)
+@inline instantiate(t::Tuple, a::Vararg{Any,N}) where {N} = _instantiate_all(a, t...)
+@inline instantiate(t::NamedTuple{names}, a::Vararg{Any,N}) where {names,N} =
+    NamedTuple{names}(_instantiate_all(a, values(t)...))
 
 """
     _anyarg(xs...)

--- a/src/argument.jl
+++ b/src/argument.jl
@@ -211,15 +211,27 @@ true
 # load-bearing for AOT — same reason on the `ExaCore` method in nlp.jl.
 # Unrolled as well as specialized: `Vararg{Any,N}` is necessary — without it
 # the vararg is not specialized at all — but on a core the size of an AC
-# OPF's (measured: 6 variable blocks, 10 constraint blocks) the `map`
-# closure is still an unresolved call under `--trim=safe`. The recursion
-# gives each element a direct `instantiate` call; semantics are unchanged.
-@inline _instantiate_all(a::Tuple) = ()
-@inline _instantiate_all(a::Tuple, x, xs...) =
-    (instantiate(x, a...), _instantiate_all(a, xs...)...)
-@inline instantiate(t::Tuple, a::Vararg{Any,N}) where {N} = _instantiate_all(a, t...)
-@inline instantiate(t::NamedTuple{names}, a::Vararg{Any,N}) where {names,N} =
-    NamedTuple{names}(_instantiate_all(a, values(t)...))
+# OPF's the `map` closure is still an unresolved call under `--trim=safe`.
+# The recursion gives each element a direct `instantiate` call.
+#
+# THE PARAMETER ROLES ARE LOAD-BEARING, both of them. The ELEMENTS stay
+# structural (`t::Tuple`, recursed via `first`/`Base.tail`): splatting them
+# into a bare vararg (`_f(a, x, xs...)`) puts the heterogeneous element
+# types into a pass-through-only vararg, which Julia leaves unspecialized —
+# the per-element types are lost, and a core whose objectives project
+# fields out of a deferred data call (gasoil's shape) widens at the
+# instantiate boundary: 6 verifier errors, reproduced and bisected to this
+# hunk alone (6 → 0 on the swap, real COPS gasoil as the instrument). The
+# ARGUMENTS ride the specialized `Vararg{Any,N}`. Inverting either role
+# reintroduces the widening; the ExaModelsC suite's models are too small
+# and too homogeneous to see it — the COPS CI pin on this branch is the
+# regression gate for this class.
+@inline _instantiate_each(::Tuple{}, a::Vararg{Any,N}) where {N} = ()
+@inline _instantiate_each(t::Tuple, a::Vararg{Any,N}) where {N} =
+    (instantiate(first(t), a...), _instantiate_each(Base.tail(t), a...)...)
+@inline instantiate(t::Tuple, a::Vararg{Any,N}) where {N} = _instantiate_each(t, a...)
+@inline instantiate(t::NamedTuple{K}, a::Vararg{Any,N}) where {K, N} =
+    NamedTuple{K}(_instantiate_each(Tuple(t), a...))
 
 """
     _anyarg(xs...)

--- a/src/argument.jl
+++ b/src/argument.jl
@@ -209,9 +209,11 @@ true
 # (Julia's passthrough heuristic), and the `map` below then carries a dynamic
 # call that `juliac --trim=safe` cannot resolve. Harmless under the JIT,
 # load-bearing for AOT — same reason on the `ExaCore` method in nlp.jl.
-# EXPERIMENT (Ohm): unrolled as well as specialized. #308's `Vararg{Any,N}`
-# is necessary — without it the vararg is not specialized at all — but on a
-# core the size of an AC OPF's the `map` closure is still unresolved.
+# Unrolled as well as specialized: `Vararg{Any,N}` is necessary — without it
+# the vararg is not specialized at all — but on a core the size of an AC
+# OPF's (measured: 6 variable blocks, 10 constraint blocks) the `map`
+# closure is still an unresolved call under `--trim=safe`. The recursion
+# gives each element a direct `instantiate` call; semantics are unchanged.
 @inline _instantiate_all(a::Tuple) = ()
 @inline _instantiate_all(a::Tuple, x, xs...) =
     (instantiate(x, a...), _instantiate_all(a, xs...)...)

--- a/src/argument.jl
+++ b/src/argument.jl
@@ -181,17 +181,17 @@ julia> ExaModels.instantiate(x, (nh = 2,)) === x     # identity, no arg dependen
 true
 ```
 """
-@inline instantiate(x, a...) = x
-@inline instantiate(::ArgSource{K}, a...) where {K} = a[K]
-@inline instantiate(n::ArgIndexed{I, J}, a...) where {I, J} =
+@inline instantiate(x, a::Vararg{Any,N}) where {N} = x
+@inline instantiate(::ArgSource{K}, a::Vararg{Any,N}) where {K, N} = a[K]
+@inline instantiate(n::ArgIndexed{I, J}, a::Vararg{Any,N}) where {I, J, N} =
     _arg_access(instantiate(getfield(n, :inner), a...), J)
-@inline instantiate(n::ArgNode1, a...) =
+@inline instantiate(n::ArgNode1, a::Vararg{Any,N}) where {N} =
     getfield(n, :f)(instantiate(getfield(n, :inner), a...))
-@inline instantiate(n::ArgNode2, a...) = getfield(n, :f)(
+@inline instantiate(n::ArgNode2, a::Vararg{Any,N}) where {N} = getfield(n, :f)(
     instantiate(getfield(n, :inner1), a...),
     instantiate(getfield(n, :inner2), a...),
 )
-@inline instantiate(n::ArgCall, a...) =
+@inline instantiate(n::ArgCall, a::Vararg{Any,N}) where {N} =
     getfield(n, :f)(map(x -> instantiate(x, a...), getfield(n, :args))...)
 
 @inline _arg_access(x, j::Symbol) = getproperty(x, j)
@@ -204,8 +204,15 @@ true
 # that looks fully instantiated and is not.  Mapping costs nothing observable:
 # an immutable tuple rebuilds `===` to itself, and each element is passed
 # through by identity when it has no dependency of its own.
-@inline instantiate(t::Tuple, a...) = map(x -> instantiate(x, a...), t)
-@inline instantiate(t::NamedTuple, a...) = map(x -> instantiate(x, a...), t)
+# `Vararg{Any,N}` forces specialization on the arguments' concrete types:
+# a vararg that is only splatted through is otherwise left unspecialized
+# (Julia's passthrough heuristic), and the `map` below then carries a dynamic
+# call that `juliac --trim=safe` cannot resolve. Harmless under the JIT,
+# load-bearing for AOT — same reason on the `ExaCore` method in nlp.jl.
+@inline instantiate(t::Tuple, a::Vararg{Any,N}) where {N} =
+    map(x -> instantiate(x, a...), t)
+@inline instantiate(t::NamedTuple, a::Vararg{Any,N}) where {N} =
+    map(x -> instantiate(x, a...), t)
 
 """
     _anyarg(xs...)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -229,6 +229,47 @@ struct Node2{F,I1,I2} <: AbstractNode
     inner2::I2
 end
 
+# ── Re-indexing a built subexpression ─────────────────────────────────────────
+#
+# `@add_expr` stores a body that is spliced in wherever it is referenced, so the
+# stored form has to be re-indexable.  A closure did that by being called again
+# with a new index; a node does it by substituting the `DataSource` it was built
+# against.
+#
+# Storing a node rather than a closure is what makes subexpressions usable in a
+# recipe.  A closure captures the `Variable`s it mentions, so when a size is a
+# placeholder the `ArgSource` ends up inside the closure's *type*, where
+# `instantiate` cannot reach it — and Julia emits no constructor for a closure,
+# so it cannot be rebuilt field-wise either.  Nodes have constructors and
+# dispatch, and the operation lives in the type parameter, so this walk is
+# static: no reflection, no `@generated`, nothing `--trim=safe` will refuse.
+@inline _reindex(::DataSource, i) = i
+@inline _reindex(n::DataIndexed{I, J}, i) where {I, J} =
+    _reindexed_access(_reindex(getfield(n, :inner), i), J)
+# Once the source has been replaced by a concrete element — an integer, or the
+# tuple a multi-dimensional or product-iterator generator destructures — the
+# lookup is no longer symbolic and has to be performed, not rebuilt.  Leaving it
+# as a `DataIndexed` around a raw tuple is what broke the multi-dim cases.
+@inline _reindexed_access(inner::AbstractNode, J) = DataIndexed(inner, J)
+@inline _reindexed_access(inner, J::Symbol) = getproperty(inner, J)
+@inline _reindexed_access(inner, J) = getindex(inner, J)
+@inline _reindex(n::Var, i) = Var(_reindex(getfield(n, :i), i))
+@inline _reindex(n::ParameterNode, i) = ParameterNode(_reindex(getfield(n, :i), i))
+@inline function _reindex(n::Node1{F}, i) where {F}
+    # Julia synthesises no partially-parameterised constructor, so the child
+    # types are given explicitly; they are known here, so this stays static.
+    inner = _reindex(getfield(n, :inner), i)
+    return Node1{F, typeof(inner)}(inner)
+end
+@inline function _reindex(n::Node2{F}, i) where {F}
+    a = _reindex(getfield(n, :inner1), i)
+    b = _reindex(getfield(n, :inner2), i)
+    return Node2{F, typeof(a), typeof(b)}(a, b)
+end
+# Leaves with no data dependence — constants, variable/parameter sources, plain
+# numbers — are their own re-indexing.
+@inline _reindex(x, i) = x
+
 struct FirstFixed{F}
     inner::F
 end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -259,11 +259,18 @@ end
     # Julia synthesises no partially-parameterised constructor, so the child
     # types are given explicitly; they are known here, so this stays static.
     inner = _reindex(getfield(n, :inner), i)
+    # A fully-concrete subterm is COMPUTED, not wrapped — the closure this
+    # storage replaces evaluated such terms eagerly, and a node with only
+    # Real children has no evaluation method (register.jl's one-sided Real
+    # methods tie for two: `s[2]` substituting into `i - 1` was ambiguous at
+    # the adjoint call). `F.instance` exists because ops are named functions.
+    inner isa Real && return F.instance(inner)
     return Node1{F, typeof(inner)}(inner)
 end
 @inline function _reindex(n::Node2{F}, i) where {F}
     a = _reindex(getfield(n, :inner1), i)
     b = _reindex(getfield(n, :inner2), i)
+    a isa Real && b isa Real && return F.instance(a, b)
     return Node2{F, typeof(a), typeof(b)}(a, b)
 end
 # Leaves with no data dependence — constants, variable/parameter sources, plain

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -542,30 +542,30 @@ end
 # (`Constant`, `Null`, `VarSource`, `DataSource`, …) fall through to the generic
 # identity in argument.jl.
 
-@inline function instantiate(n::Var{I}, a...) where {I}
+@inline function instantiate(n::Var{I}, a::Vararg{Any,N}) where {I, N}
     i = instantiate(n.i, a...)
     return Var{typeof(i)}(i)
 end
-@inline function instantiate(n::ParameterNode{I}, a...) where {I}
+@inline function instantiate(n::ParameterNode{I}, a::Vararg{Any,N}) where {I, N}
     i = instantiate(n.i, a...)
     return ParameterNode{typeof(i)}(i)
 end
-@inline function instantiate(n::Node1{F,I}, a...) where {F,I}
+@inline function instantiate(n::Node1{F,I}, a::Vararg{Any,N}) where {F,I, N}
     i = instantiate(n.inner, a...)
     return Node1{F,typeof(i)}(i)
 end
-@inline function instantiate(n::Node2{F,I1,I2}, a...) where {F,I1,I2}
+@inline function instantiate(n::Node2{F,I1,I2}, a::Vararg{Any,N}) where {F,I1,I2, N}
     i1 = instantiate(n.inner1, a...)
     i2 = instantiate(n.inner2, a...)
     return Node2{F,typeof(i1),typeof(i2)}(i1, i2)
 end
-@inline instantiate(n::SumNode, a...) = SumNode(instantiate(n.inners, a...))
-@inline instantiate(n::ProdNode, a...) = ProdNode(instantiate(n.inners, a...))
+@inline instantiate(n::SumNode, a::Vararg{Any,N}) where {N} = SumNode(instantiate(n.inners, a...))
+@inline instantiate(n::ProdNode, a::Vararg{Any,N}) where {N} = ProdNode(instantiate(n.inners, a...))
 # `DataIndexed` overrides `getproperty` to keep building access paths, so its
 # own field has to be read with `getfield`.
-@inline instantiate(n::DataIndexed{I,J}, a...) where {I,J} =
+@inline instantiate(n::DataIndexed{I,J}, a::Vararg{Any,N}) where {I,J, N} =
     DataIndexed(instantiate(getfield(n, :inner), a...), J)
-@inline instantiate(p::Pair, a...) = instantiate(p.first, a...) => instantiate(p.second, a...)
+@inline instantiate(p::Pair, a::Vararg{Any,N}) where {N} = instantiate(p.first, a...) => instantiate(p.second, a...)
 # An `ArgLeaf` does not survive instantiation: it *becomes* the scalar, leaving
 # a graph indistinguishable from one built with concrete sizes.
-@inline instantiate(n::ArgLeaf, a...) = instantiate(getfield(n, :a), a...)
+@inline instantiate(n::ArgLeaf, a::Vararg{Any,N}) where {N} = instantiate(getfield(n, :a), a...)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -579,7 +579,9 @@ is known statically and destructuring stays inferable.
 # rather than re-derived: it is the float type the core was created with, and
 # instantiating changes sizes, never the element type.
 
-function instantiate(c::ExaCore{T}, a...) where {T}
+# `Vararg{Any,N}`: see the note on the `Tuple` method in argument.jl — forces
+# specialization so the field-by-field mapping stays static under `--trim`.
+function instantiate(c::ExaCore{T}, a::Vararg{Any,N}) where {T, N}
     return ExaCore{T}(
         c.name,
         c.backend,
@@ -613,24 +615,24 @@ function instantiate(c::ExaCore{T}, a...) where {T}
     )
 end
 
-instantiate(v::Variable, a...) =
+instantiate(v::Variable, a::Vararg{Any,N}) where {N} =
     Variable(instantiate(v.size, a...), instantiate(v.length, a...), instantiate(v.offset, a...),
              v.name, instantiate(v.tag, a...))
-instantiate(p::Parameter, a...) =
+instantiate(p::Parameter, a::Vararg{Any,N}) where {N} =
     Parameter(instantiate(p.size, a...), instantiate(p.length, a...), instantiate(p.offset, a...),
               instantiate(p.tag, a...))
-instantiate(e::Expression, a...) =
+instantiate(e::Expression, a::Vararg{Any,N}) where {N} =
     Expression(instantiate(e.size, a...), instantiate(e.length, a...), instantiate(e.f, a...),
                instantiate(e.iter, a...), instantiate(e.tag, a...))
-instantiate(o::Objective, a...) = Objective(instantiate(o.f, a...), instantiate(o.itr, a...))
-instantiate(c::Constraint, a...) =
+instantiate(o::Objective, a::Vararg{Any,N}) where {N} = Objective(instantiate(o.f, a...), instantiate(o.itr, a...))
+instantiate(c::Constraint, a::Vararg{Any,N}) where {N} =
     Constraint(instantiate(c.f, a...), instantiate(c.itr, a...), instantiate(c.offset, a...),
                instantiate(c.size, a...), instantiate(c.tag, a...))
-instantiate(c::ConstraintAugmentation, a...) =
+instantiate(c::ConstraintAugmentation, a::Vararg{Any,N}) where {N} =
     ConstraintAugmentation(instantiate(c.f, a...), instantiate(c.itr, a...),
                            instantiate(c.oa, a...), instantiate(c.dims, a...),
                            instantiate(c.tag, a...))
-instantiate(f::SIMDFunction, a...) =
+instantiate(f::SIMDFunction, a::Vararg{Any,N}) where {N} =
     SIMDFunction(instantiate(f.f, a...), f.comp1, f.comp2,
                  instantiate(f.o0, a...), instantiate(f.o1, a...), instantiate(f.o2, a...),
                  f.o1step, f.o2step)
@@ -1048,11 +1050,11 @@ end
 
 # `start = (f(i) for i in 1:arg.N)` — the body is untouched (it runs per element
 # once the iterator is concrete); only what it iterates is deferred.
-@inline instantiate(g::Base.Generator, a...) = Base.Generator(g.f, instantiate(g.iter, a...))
+@inline instantiate(g::Base.Generator, a::Vararg{Any,N}) where {N} = Base.Generator(g.f, instantiate(g.iter, a...))
 
 # A product iterator is arg-dependent when any of the ranges it crosses is.
 @inline _anyarg(p::Base.Iterators.ProductIterator, xs...) = _anyarg(p.iterators..., xs...)
-@inline instantiate(p::Base.Iterators.ProductIterator, a...) =
+@inline instantiate(p::Base.Iterators.ProductIterator, a::Vararg{Any,N}) where {N} =
     Base.Iterators.product(instantiate(p.iterators, a...)...)
 
 # `append!` mutates its accumulator and returns it.  That is exactly right while

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -2120,6 +2120,15 @@ function multipliers(result::SolverCore.AbstractExecutionStats, y::Constraint)
 end
 
 _adapt_gen(gen) = Base.Generator(gen.f, collect(gen.iter))
+# A placeholder iterable resolves at instantiation, so what to do with it can
+# only be decided then. The unconditional deferred `collect` was wrong on the
+# GPU: `collect(::CuArray)` is a host Vector, so a converted argument was
+# silently pulled back to the CPU and the kernel met a non-bitstype — invisible
+# on the CPU, where `collect` of a Vector is just a copy.
+_maybe_collect(x) = collect(x)
+_maybe_collect(x::Union{AbstractArray, AbstractRange}) = x
+@inline _adapt_gen(gen::Base.Generator{I}) where {I<:AbstractArgNode} =
+    Base.Generator(gen.f, ArgCall(_maybe_collect, (gen.iter,)))
 # `for i in 1:nh, j in 1:nc` over symbolic ranges: `collect` on the product
 # needs `axes`, and `axes` needs concrete lengths, so it cannot run yet.  Defer
 # the collect itself — it happens at instantiation, on real ranges.

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -58,7 +58,7 @@ end
 Base.show(io::IO, s::Expression) = _show_expression(io, s)
 function _show_expression(io::IO, s::Expression)
     expr = try
-        _expr_string(s.f(DataSource()))
+        _expr_string(s.f)
     catch
         "(?)"
     end
@@ -926,24 +926,24 @@ end
 @inline function Base.getindex(s::Expression, i::I) where {I <: Integer}
     _bound_check(s.size, i)
     idx = i - _start(s.size[1]) + 1
-    return s.f(s.iter[idx])
+    return _reindex(s.f, s.iter[idx])
 end
 @inline function Base.getindex(s::Expression, i)
     # Symbolic index case - the symbolic index IS the iterator element
     # No adjustment needed; the index is used directly in expression building
-    return s.f(i)
+    return _reindex(s.f, i)
 end
 @inline function Base.getindex(s::Expression, is::Vararg{I, N}) where {I <: Integer, N}
     @assert(length(is) == length(s.size), "Expression index dimension error")
     _bound_check(s.size, is)
     idx = idxx(is .- (_start.(s.size) .- 1), _length.(s.size))
-    return s.f(s.iter[idx])
+    return _reindex(s.f, s.iter[idx])
 end
 @inline function Base.getindex(s::Expression, is...)
     # Symbolic indices case - the symbolic indices ARE the iterator elements
     # No adjustment needed; the indices are used directly in expression building
     @assert(length(is) == length(s.size), "Expression index dimension error")
-    return s.f(is)
+    return _reindex(s.f, is)
 end
 
 @inline function Base.getindex(p::P, i) where {P<:Parameter}
@@ -1746,7 +1746,9 @@ c, s = add_expr(c, x[i, k]^2 for (i, k) in itr)
     gen = _adapt_gen(gen)
     n = length(gen.iter)
 
-    ex = Expression(ns, n, gen.f, collect(gen.iter), tag)
+    # Store the body as a node, built once against a `DataSource`, rather than
+    # as the generator's closure — see `_reindex` in graph.jl.
+    ex = Expression(ns, n, gen.f(DataSource()), collect(gen.iter), tag)
     return (ExaCore(c; refs = add_refs(c.refs, name, ex)), ex)
 end
 

--- a/test/ArgumentTest/ArgumentTest.jl
+++ b/test/ArgumentTest/ArgumentTest.jl
@@ -396,6 +396,31 @@ function runtests()
             @test repr(1:arg.N) == "(1:arg.N)"
             @test repr(length(arg.v)) == "length(arg.v)"
         end
+
+        @testset "a converted iterable stays on its backend" begin
+            # The deferred collect in _adapt_gen must not migrate an argument
+            # back to the host: collect(::CuArray) is a Vector, so a recipe
+            # instantiated with device-converted arguments produced a model
+            # whose kernels met a non-bitstype host array. Invisible on the
+            # CPU, where collect of a Vector is just a copy — which is why
+            # this asserts RESIDENCE, not values.
+            for backend in Main.BACKENDS
+                backend === nothing && continue
+                c, d = ExaModels.ExaCore(nargs = Val(1))
+                ExaModels.@add_var(c, x, length(d.rows))
+                ExaModels.@add_obj(c, (x[r.i] - r.w)^2 for r in d.rows)
+                rows = [(i = i, w = Float64(i)) for i = 1:5]
+                dev = ExaModels.convert_array(rows, backend)
+                m = ExaModels.ExaModel(c, (; rows = dev); backend = backend)
+                @testset "$backend" begin
+                    # Residence via typeof equality. Only a device backend
+                    # discriminates — on CPU() the converted array IS a Vector,
+                    # so the pre-fix collect was a same-type copy there; the
+                    # CUDA leg is the one this test exists for.
+                    @test typeof(m.objs[1].itr) == typeof(dev)
+                end
+            end
+        end
     end
 end
 

--- a/test/NLPTest/subexpr_test.jl
+++ b/test/NLPTest/subexpr_test.jl
@@ -4,6 +4,28 @@
 Test basic 1D subexpression creation and solving.
 Compares a model with subexpressions to an equivalent model without.
 """
+
+function test_subexpr_concrete_index_constant_term(backend)
+    # A standalone scalar term in the body (`i - 1`) plus a CONCRETE index
+    # into the expression: substitution then hands the stored `-` node two
+    # Real children. The node storage that replaced the body closure must
+    # fold that case eagerly, as the closure did — left as a node it has no
+    # evaluation method (the one-sided Real methods tie), and the failure
+    # surfaced at the ADJOINT call, so the gradient is the assertion here.
+    c = ExaCore(; backend = backend, concrete = Val(true))
+    @add_var(c, x, 4; start = [1.0, 2.0, 3.0, 4.0])
+    @add_expr(c, s, x[i] + (i - 1) for i in 1:4)
+    @add_obj(c, (s[2] + x[i])^2 for i in 1:4)
+    m = ExaModel(c)
+    x0 = Array(m.meta.x0)                      # host copy for reference math
+    want = sum((x0[2] + 1 + x0[i])^2 for i in 1:4)
+    @test NLPModels.obj(m, m.meta.x0) ≈ want
+    g = NLPModels.grad(m, m.meta.x0)
+    gwant = [2 * (x0[2] + 1 + x0[i]) for i in 1:4]
+    gwant[2] += sum(2 * (x0[2] + 1 + x0[i]) for i in 1:4)
+    @test Array(g) ≈ gwant
+end
+
 function test_subexpr_basic(backend)
     # Model WITHOUT subexpressions
     c1 = ExaCore(; backend = backend, concrete = Val(true))
@@ -449,6 +471,10 @@ function test_subexpr(backend)
 
     @testset "Subexpr reduced 0-based nested" begin
         test_subexpr_reduced_0based_nested(backend)
+    end
+
+    @testset "Subexpr concrete index with constant term" begin
+        test_subexpr_concrete_index_constant_term(backend)
     end
 
 end


### PR DESCRIPTION
`compile_library` now takes any number of `:name => core` / `:name => (core, args...)` pairs and compiles them into one shared library, each model under its own symbol prefix — and, per model, compiles **any argument shape `ExaModel` takes**, emitting the matching instantiation surface:

```julia
compile_library("@grid",
    :acopf  => (ac_core, 100),                 # one integer → acopf_new(n)
    :struct => (s_core, 4,                     # several values → the builder ABI
                (v0 = fill(0.5, 4), lo = fill(-10.0, 4)),
                [(i = 1, w = 2.0, s = 1.0)]),
    :opf    => (opf_core, ac_opf_args, "case14.m"),  # argument function → opf_new_str
    :fixed  => small_core)                     # no instantiation data
```

**Multi-model:** the generated module suffixes all per-model state (`CORE_$p`, `MODELS_$p`, ...), so models keep separate cores, instance tables, and ids; the library FILE is named after `out`, the model names supply the prefixes.

**Structured instantiation:** recipes whose examples are not a single integer emit the ABI v2 schema + builder surface both consumers already implement — `P_schema` publishes the flattened field list, typed setters take values by name, `P_new_from_data` reassembles the `ExaModel` arguments. Builder storage is generated concretely from the example types (`Int64`/`Float64` exactly; anything looser is refused with the reason).

**Argument functions:** `argfun = f` (or a `Function` in the pair's second position — nothing callable can be a model argument, so the spelling is unambiguous) carries `f` into the library and calls it at run time: only `f`'s own argument crosses the boundary — one string (`P_new_str`) or one integer (`P_new`) — and the work that turns it into instantiation data happens inside. `f` must be a **named function owned by a package proper**: functions from scripts/REPL (unreachable from the generated app) and from package *extensions* (their module is not a name the app imports) are refused in the first second with the constraint named, rather than dying minutes into juliac.

**Every model exports `P_argkind() -> 0|1|2|3`** (fixed, `P_new(n)`, `P_new_str`, builder), so a consumer routes on declared shape instead of probing symbols; kind 1 covers n-is-the-size and n-goes-to-the-function indistinguishably **by design**. `P_nargs` (how many) and `P_argkind` (what shape) are the two halves a consumer handed only a library path needs.

**Subexpressions work in recipes:** `@add_expr` now stores its body as a node (substituted via a static `_reindex` walk) rather than a closure — a closure captures the `Variable`s it mentions, putting a placeholder's `ArgSource` into the closure's *type*, where `instantiate` cannot reach it. Verified against a measured main baseline (1617/0/2, identical), plus empirical probes of `sum(...)` inside bodies, including index-dependent summands (exact).

**Developed packages are pinned:** every package the caller tracks by path becomes a `[deps]` + `[sources]` entry of the generated app (not an import — resolution needs the pin; only the cores' own types need imports), so the app compiles the code the caller runs rather than the registry copy. Also in ExaModels proper: `instantiate`'s varargs are specialization-forced (`Vararg{Any,N}`) *and* the container walk is unrolled — both are needed; large cores (AC OPF scale) leave `map` closures unresolved under `--trim=safe` with the annotation alone.

Suite: **210/210** on Linux against current consumer masters — a three-model round-trip, the four-surface library (builder + one-knob + argfun:int + argfun:str in one file), Ipopt solves through both surfaces, refusal tests (strings, loose types, colliding names, script-, Main-, and extension-owned functions). Scale datum from independent review: an **18-model library assembles in 160 s with 0 verifier errors**, exact readback at an unseen size. GPU datum from downstream validation: a real modelling library's CUDA test slice (ExaModelsPower#57, 322 tests) runs green against this branch's instantiation path — the leg that was dead before the `collect` fix.

Note for path-dev consumers: this adds `Pkg` to ExaModelsC's dependencies — a stale manifest that path-devs ExaModelsC reports `Package ExaModelsC does not have Pkg in its dependencies` until `Pkg.resolve()`; that is the manifest, not the branch.

Consumer-side name selection (`CNLPModel(lib, :acopf, ...)`) is already on CNLPModels master; the `_new_str`/`_argkind` routing follows as separate consumer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)