### PR TITLE
compile_all: a template for compiling everything a package provides

### DIFF
--- a/ExaModelsCompiler/src/ExaModelsCompiler.jl
+++ b/ExaModelsCompiler/src/ExaModelsCompiler.jl
@@ -1744,7 +1744,7 @@ end
 # ── Compiling everything a package provides ──────────────────────────────────
 
 """
-    compile_all(SomePackage; path = "@name", only = nothing, exclude = (), kwargs...)
+    compile_all(SomePackage; path = "@name", kwargs...)
     compile_all(Val(SomePackage); ...)
 
 Compile every model a package provides into **one** shared library.
@@ -1756,7 +1756,6 @@ and its keywords mean the same thing everywhere:
   - `path` — where the library goes, as [`compile_library`](@ref) takes it
     (`"@cops"` installs on the `CNLPMODELS_PATH`); each package picks its own
     default name.
-  - `only` / `exclude` — model names to keep or drop; see [`select`](@ref).
   - everything else is forwarded to `compile_library` (`bundle`, `trim`, …).
 
 One library rather than one per model: sizes are deferred, so the models share
@@ -1783,18 +1782,16 @@ COPSBenchmarkExaModelsCompilerExt = "ExaModelsCompiler"
 module COPSBenchmarkExaModelsCompilerExt
 
 import COPSBenchmark, ExaModelsCompiler
-using ExaModelsCompiler: compile_library, select
+using ExaModelsCompiler: compile_library
 
-function ExaModelsCompiler.compile_all(
-    ::Val{COPSBenchmark}; path = "@cops", only = nothing, exclude = (), kwargs...,
-)
+function ExaModelsCompiler.compile_all(::Val{COPSBenchmark}; path = "@cops", kwargs...)
     b = COPSBenchmark.ExaModelsBackend()
     models = [
         :bearing => (COPSBenchmark.bearing_recipe(b), COPSBenchmark.bearing_args(b, 50, 50)...),
         :chain   => (COPSBenchmark.chain_recipe(b),   COPSBenchmark.chain_args(b, 800)...),
         # ...
     ]
-    return compile_library(path, select(models; only, exclude)...; kwargs...)
+    return compile_library(path, models...; kwargs...)
 end
 
 end
@@ -1820,32 +1817,6 @@ function compile_all(::Val{M}; kwargs...) where {M}
         "`compile_all` docstring for the shape. If $M does implement it, load " *
         "both packages before calling: the extension only comes up once " *
         "ExaModelsCompiler is in scope."))
-end
-
-"""
-    select(models; only = nothing, exclude = ())
-
-Filter `:name => spec` model pairs for [`compile_all`](@ref): keep `only` (all
-of them when `nothing`), drop `exclude`. Names may be symbols or strings.
-
-Refuses a name that is not in `models` rather than silently compiling less than
-asked for — a typo in `only` would otherwise produce a library quietly missing
-a model.
-"""
-function select(models; only = nothing, exclude = ())
-    have = Set(first.(models))
-    _sym(x) = x isa Symbol ? x : Symbol(x)
-    for name in Iterators.flatten((only === nothing ? () : only, exclude))
-        _sym(name) in have || throw(ArgumentError(
-            "no model named `$(_sym(name))`; this package provides " *
-            "$(sort(collect(have)))"))
-    end
-    keep = only === nothing ? have : Set(_sym.(only))
-    setdiff!(keep, Set(_sym.(exclude)))
-    out = [p for p in models if first(p) in keep]
-    isempty(out) && throw(ArgumentError(
-        "`only`/`exclude` selected no models out of $(sort(collect(have)))"))
-    return out
 end
 
 end # module ExaModelsCompiler

--- a/ExaModelsCompiler/src/ExaModelsCompiler.jl
+++ b/ExaModelsCompiler/src/ExaModelsCompiler.jl
@@ -81,7 +81,7 @@ import Random
 import Serialization
 import TOML
 
-export compile_library
+export compile_library, compile_all
 
 # The generated app package is a throwaway: a fresh temporary directory with
 # its own environment, never registered.  A constant UUID is therefore safe and
@@ -1739,6 +1739,113 @@ function _link(::Val{false}, img, libname, outdir)
     JuliaC.link_products(link)
     isfile(libpath) || error("juliac produced no library at $libpath")
     return (; libpath, outdir, libname)
+end
+
+# ── Compiling everything a package provides ──────────────────────────────────
+
+"""
+    compile_all(SomePackage; path = "@name", only = nothing, exclude = (), kwargs...)
+    compile_all(Val(SomePackage); ...)
+
+Compile every model a package provides into **one** shared library.
+
+Call it with the package itself; a package that ships models implements the
+`Val` form for itself, so it decides how its models are assembled — sizes, argument functions, element type — while the verb
+and its keywords mean the same thing everywhere:
+
+  - `path` — where the library goes, as [`compile_library`](@ref) takes it
+    (`"@cops"` installs on the `CNLPMODELS_PATH`); each package picks its own
+    default name.
+  - `only` / `exclude` — model names to keep or drop; see [`select`](@ref).
+  - everything else is forwarded to `compile_library` (`bundle`, `trim`, …).
+
+One library rather than one per model: sizes are deferred, so the models share
+a runtime and one compile amortises across all of them, and a consumer selects
+with `CNLPModel(lib, :bearing, n)`.
+
+## Implementing it
+
+Put it in a package extension, so providing models costs no dependency on this
+package — `ExaModelsCompiler` pulls in a compiler toolchain, and a package of
+models should not:
+
+```julia
+# Project.toml
+[weakdeps]
+ExaModelsCompiler = "3d1e9a26-5b74-4f0c-9a2b-7c8f4e11d3a7"
+
+[extensions]
+COPSBenchmarkExaModelsCompilerExt = "ExaModelsCompiler"
+```
+
+```julia
+# ext/COPSBenchmarkExaModelsCompilerExt.jl
+module COPSBenchmarkExaModelsCompilerExt
+
+import COPSBenchmark, ExaModelsCompiler
+using ExaModelsCompiler: compile_library, select
+
+function ExaModelsCompiler.compile_all(
+    ::Val{COPSBenchmark}; path = "@cops", only = nothing, exclude = (), kwargs...,
+)
+    b = COPSBenchmark.ExaModelsBackend()
+    models = [
+        :bearing => (COPSBenchmark.bearing_recipe(b), COPSBenchmark.bearing_args(b, 50, 50)...),
+        :chain   => (COPSBenchmark.chain_recipe(b),   COPSBenchmark.chain_args(b, 800)...),
+        # ...
+    ]
+    return compile_library(path, select(models; only, exclude)...; kwargs...)
+end
+
+end
+```
+
+A model taking an argument function is spelled as it is for `compile_library` —
+`:acopf => (core, opf_args, "case14.m")` — so a package whose models are
+data-defined compiles to a library that parses a case file itself.
+"""
+function compile_all end
+
+# The spelling a caller uses: name the package, not a `Val` of it. Providers
+# implement the `Val` method — one uniform handle, no per-package type to look
+# up — and this forwards to it.
+compile_all(m::Module; kwargs...) = compile_all(Val(m); kwargs...)
+
+# Reached when the package has no method — either it provides no models, or its
+# extension is not loaded because this package was not in scope when it was.
+function compile_all(::Val{M}; kwargs...) where {M}
+    throw(ArgumentError(
+        "$M does not implement `compile_all`. A package that provides models " *
+        "implements it in an ExaModelsCompiler extension — see the " *
+        "`compile_all` docstring for the shape. If $M does implement it, load " *
+        "both packages before calling: the extension only comes up once " *
+        "ExaModelsCompiler is in scope."))
+end
+
+"""
+    select(models; only = nothing, exclude = ())
+
+Filter `:name => spec` model pairs for [`compile_all`](@ref): keep `only` (all
+of them when `nothing`), drop `exclude`. Names may be symbols or strings.
+
+Refuses a name that is not in `models` rather than silently compiling less than
+asked for — a typo in `only` would otherwise produce a library quietly missing
+a model.
+"""
+function select(models; only = nothing, exclude = ())
+    have = Set(first.(models))
+    _sym(x) = x isa Symbol ? x : Symbol(x)
+    for name in Iterators.flatten((only === nothing ? () : only, exclude))
+        _sym(name) in have || throw(ArgumentError(
+            "no model named `$(_sym(name))`; this package provides " *
+            "$(sort(collect(have)))"))
+    end
+    keep = only === nothing ? have : Set(_sym.(only))
+    setdiff!(keep, Set(_sym.(exclude)))
+    out = [p for p in models if first(p) in keep]
+    isempty(out) && throw(ArgumentError(
+        "`only`/`exclude` selected no models out of $(sort(collect(have)))"))
+    return out
 end
 
 end # module ExaModelsCompiler

--- a/ExaModelsCompiler/test/runtests.jl
+++ b/ExaModelsCompiler/test/runtests.jl
@@ -33,6 +33,11 @@ const OUT = get(ENV, "EXAMODELSCOMPILER_TEST_OUT", joinpath(tempdir(), "examodel
 # the world has advanced by the time the guard's preceding probe calls it.
 Main.eval(:(script_argfun(n) = (Int(n),)))
 
+# A stand-in provider for the `compile_all` template: a package implements the
+# `Val` form, and this stands where that method would be. Defined here so the
+# world has advanced by the time the testset calls it.
+ExaModelsCompiler.compile_all(::Val{Main}; path = "x", kwargs...) = (path, :fromval)
+
 # A recipe whose blocks are all NAMED — a variable, a parameter and a
 # constraint — so the compiled library has a layout to publish and live
 # parameter state to read and write.
@@ -490,6 +495,31 @@ function runtests()
                 OUT, :a => (c, 4), :b => c)
             # `prefix =` has no meaning when the names supply the prefixes.
             @test_throws MethodError compile_library(OUT, :a => (c, 4); prefix = "z")
+        end
+
+        @testset "compile_all is a template packages implement" begin
+            # A package that has not implemented it says so, and says where it
+            # would go — the likely cause is an extension that is not loaded.
+            @test_throws "does not implement `compile_all`" ExaModelsCompiler.compile_all(
+                Val(Base); path = "/tmp/nope")
+            # A package implements the `Val` form; callers name the package
+            # and the wrapper forwards. (The stand-in method is defined at the
+            # top of this file: a method defined inside the testset would be
+            # too new for a call in the same scope to see.)
+            @test ExaModelsCompiler.compile_all(Val(Main); path = "y") == ("y", :fromval)
+            @test ExaModelsCompiler.compile_all(Main; path = "y") == ("y", :fromval)
+
+            # `select` is the shared half: the same `only`/`exclude` contract
+            # for every provider, and a typo is refused rather than quietly
+            # compiling a library with a model missing.
+            models = [:a => (1,), :b => (2,), :c => (3,)]
+            @test first.(ExaModelsCompiler.select(models)) == [:a, :b, :c]
+            @test first.(ExaModelsCompiler.select(models; only = [:c, :a])) == [:a, :c]
+            @test first.(ExaModelsCompiler.select(models; exclude = ["b"])) == [:a, :c]
+            @test first.(ExaModelsCompiler.select(models; only = [:a, :b], exclude = [:a])) == [:b]
+            @test_throws "no model named `d`" ExaModelsCompiler.select(models; only = [:d])
+            @test_throws "no model named `d`" ExaModelsCompiler.select(models; exclude = [:d])
+            @test_throws "selected no models" ExaModelsCompiler.select(models; only = [:a], exclude = [:a])
         end
 
         @testset "an argument function is checked before it is compiled" begin

--- a/ExaModelsCompiler/test/runtests.jl
+++ b/ExaModelsCompiler/test/runtests.jl
@@ -509,17 +509,6 @@ function runtests()
             @test ExaModelsCompiler.compile_all(Val(Main); path = "y") == ("y", :fromval)
             @test ExaModelsCompiler.compile_all(Main; path = "y") == ("y", :fromval)
 
-            # `select` is the shared half: the same `only`/`exclude` contract
-            # for every provider, and a typo is refused rather than quietly
-            # compiling a library with a model missing.
-            models = [:a => (1,), :b => (2,), :c => (3,)]
-            @test first.(ExaModelsCompiler.select(models)) == [:a, :b, :c]
-            @test first.(ExaModelsCompiler.select(models; only = [:c, :a])) == [:a, :c]
-            @test first.(ExaModelsCompiler.select(models; exclude = ["b"])) == [:a, :c]
-            @test first.(ExaModelsCompiler.select(models; only = [:a, :b], exclude = [:a])) == [:b]
-            @test_throws "no model named `d`" ExaModelsCompiler.select(models; only = [:d])
-            @test_throws "no model named `d`" ExaModelsCompiler.select(models; exclude = [:d])
-            @test_throws "selected no models" ExaModelsCompiler.select(models; only = [:a], exclude = [:a])
         end
 
         @testset "an argument function is checked before it is compiled" begin


### PR DESCRIPTION
Stacked on #311 (base is that branch) so it can land after it, or fold in if you'd rather.

`ExaModelsCompiler` declares the verb and owns the keyword contract; a package that ships models implements it for itself in an extension, so **providing models never costs a dependency on a compiler toolchain** — a benchmark set is a modelling package, and juliac is not something you should acquire by loading one.

```julia
compile_all(LuksanVlcekBenchmark; path = "@lvb", sizes = 1000)
```

Callers name the package; providers implement `compile_all(::Val{TheirModule}; …)`. `Val` is the uniform handle — every provider spells it the same way, and it works for a package that has no marker type of its own (ExaModelsPower has none today). The module method is a one-line wrapper over it.

One library rather than one per model, because sizes are deferred: the models share a runtime, one compile amortises across all of them, and a consumer selects with `CNLPModel(lib, :bearing, n)`.

## Verification

Against **LuksanVlcekBenchmark** on its recipes branch, with a draft extension over its eighteen models: compiled `:rosenrock` and `:broyden_banded` into one library, instantiated both at a size never compiled (37), **exact against the in-Julia models** on objective and gradient. ExaModelsCompiler suite **246/246**.

The docstring carries a complete worked extension (weakdeps stanza, ext module, the argument-function spelling for data-defined models) so a provider implements it by copying. @Ohm and @Nabla are testing it against ExaModelsPower and COPS/LVB respectively — emp is the interesting case, since its models take an argument function rather than sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)