### PR TITLE
An axis is measured by its length, whatever iterates it

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1035,15 +1035,15 @@ end
 @inline total(ns) = _total(ns...)
 @inline _total() = 1
 @inline _total(n, ns...) = _length(n) * _total(ns...)
-@inline _length(n::Int) = n
-@inline _length(n::UnitRange) = length(n)
-# A DATA axis: a constraint or objective may iterate a collection of data
-# points (`for (i, tau) in nodes`), and that collection is then one axis of
-# the block's size field. Its extent is its length, like a range's — without
-# this method, `size`/`total`/`multipliers` on such a block threw a
-# MethodError, so a compiled library's layout query failed (status 2) for
-# every model with a data-driven axis: six of COPS's seventeen.
-@inline _length(n::AbstractArray) = length(n)
+@inline _length(n::Integer) = Int(n)
+# Every other axis is measured by its LENGTH, whatever iterates it: a range,
+# a collection of data points (`for (i, tau) in nodes` — catmix's collocation
+# table), a zipped pair (`for (i, v) in zip(2:4, angles)` — steering's
+# boundary conditions). A number is the count itself (above), and a symbolic
+# node defers (below); everything else answers `length`. Enumerating iterator
+# types here was the losing game: each new model brought the next one, each
+# time as a swallowed status 2 in a compiled library's layout query.
+@inline _length(n) = length(n)
 @inline size(ns) = _size(ns...)
 @inline _size() = ()
 @inline _size(n, ns...) = (_length(n), _size(ns...)...)

--- a/test/NLPTest/feature_test.jl
+++ b/test/NLPTest/feature_test.jl
@@ -141,6 +141,18 @@ function test_add_par_dims(backend)
         b = get_cons(m, :dax)
         @test ExaModels.size(b.size) == (3, 2)
         @test ExaModels.total(b.size) == 6
+        # A ZIP axis measures the same way — steering's boundary conditions,
+        # `for (i, v) in zip(2:4, angles)`, were the second iterator type to
+        # arrive as a swallowed status 2; the rule is now general (an axis is
+        # measured by its length) rather than per-type.
+        c2 = ExaCore(; backend, concrete = Val(true))
+        c2, y = add_var(c2, 6; start = 0.0)
+        c2, z = add_con(c2, y[i] - v for (i, v) in zip(2:4, [5.0, 45.0, 0.0]);
+                        lcon = 0.0, ucon = 0.0, name = Val(:zax))
+        m2 = ExaModel(c2)
+        b2 = get_cons(m2, :zax)
+        @test ExaModels.size(b2.size) == (3,)
+        @test ExaModels.total(b2.size) == 3
     end
 
     @testset "set_value! with range-sized parameter" begin


### PR DESCRIPTION
First fix of the release-candidate iteration (per the PR-per-fix loop).

COPS field testing supplied two iterator types in sequence: catmix's collocation table (fixed by `_length(::AbstractArray)` in #313) and then steering's `zip(2:4, angles)` boundary conditions — the same failure shape, a MethodError swallowed into a status-2 layout query that leaves the model unconstructable through the consumer while compiling clean. Enumerating iterator types is the losing game, so this generalizes the rule: **a number is the count itself, a symbolic node defers, every other axis answers `length`**.

Verified by sweeping **all seventeen COPS models** (each built with its own `_args` defaults): every block of every model resolves to integer dims. Regression test covers the zip axis beside the data axis. Gates: ExaModels **1623 / 0 failed / 2 broken**, ExaModelsCompiler **252/252**.

Unblocks: `steering` (the last of Nabla's original six), and COPS's full 35-model verification round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)