### PR TITLE
Codecov: org token with per-job flags, replacing OIDC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  # codecov-action authenticates its uploads over OIDC
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,7 +51,13 @@ jobs:
         if: matrix.julia-version == '1' && matrix.os == 'ubuntu-latest'
         with:
           files: lcov.info
-          use_oidc: true
+          # Each job covers a different slice of src; flag the uploads so
+          # Codecov merges the partial reports for a commit instead of
+          # treating each as a replacement. Token, not OIDC: OIDC uploads
+          # broke on the org transfer ("Repository not found") while
+          # token-authenticated uploads kept working.
+          flags: github
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   cpu:
     strategy:
@@ -99,7 +103,8 @@ jobs:
       if: matrix.julia-version == '1'
       with:
         files: lcov.info
-        use_oidc: true
+        flags: cpu
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   gpu:
     strategy:
@@ -164,7 +169,8 @@ jobs:
       if: matrix.julia-version == '1' && matrix.backend == 'cuda'
       with:
         files: lcov.info
-        use_oidc: true
+        flags: gpu-${{ matrix.backend }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   metal:
     strategy:
@@ -395,4 +401,5 @@ jobs:
         if: matrix.name == 'linux'
         with:
           files: lcov.info
-          use_oidc: true
+          flags: examodelscompiler
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Diagnosis, with receipts: every OIDC upload since the org transfer is rejected — the upload step logs `error -- Upload queued for processing failed: {"message":"Repository not found"}` and then reports **success** (fail-open), so CI stayed green through a four-day coverage blackout. The codecov API shows **zero commits ever** for `madsuite-org/ExaModels.jl`; the old `exanauts` slug's reports end at the transfer (Aug 10 18:45). The consumers' uploads stopped in the same minute on Aug 11, pointing at the org-level app/authorization change.

Fix per the working template (ExaModelsPower): the four upload sites use the **org-level `CODECOV_TOKEN`** with distinct `flags` (`github`, `cpu`, `gpu-<backend>`, `examodelscompiler`) so Codecov merges the per-slice partial reports for a commit instead of treating each as a replacement. `id-token: write` and the OIDC rationale comment are removed. Repo-level `CODECOV_TOKEN` shadows on ExaModels.jl and ExaModelsPower.jl are deleted, so the org secret is the single source.

CNLPModels.jl and cnlpmodels-py get the same switch on their masters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)