### PR TITLE
ExaModelsCompiler: registration prerequisites

### DIFF
--- a/ExaModelsCompiler/LICENSE
+++ b/ExaModelsCompiler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Sungho Shin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ExaModelsCompiler/Project.toml
+++ b/ExaModelsCompiler/Project.toml
@@ -15,4 +15,6 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 ExaModels = {path = ".."}
 
 [compat]
+ExaModels = "0.12"
+JuliaC = "0.3"
 julia = "1.12"


### PR DESCRIPTION
Two blockers for registering ExaModelsCompiler as a subdir package, found by checking the AutoMerge guidelines before firing: the **subdirectory has no LICENSE** (AutoMerge inspects the subdir tree; the repo root's doesn't count), and **`[compat]` bounds ExaModels and JuliaC are missing** (required for all non-stdlib deps; `Pkg`/`Random`/`Serialization`/`TOML` are stdlibs and exempt). MIT copied from the repo root; `ExaModels = "0.12"`, `JuliaC = "0.3"` (current General release is 0.3.8).

Once this merges — and once ExaModels 0.12.0's own registration (fired, in flight) lands in General so the dependency resolves — the registration is one comment: `@JuliaRegistrator register subdir=ExaModelsCompiler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)