### PR TITLE
CITATION.cff; README badges in series

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,48 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+authors:
+  - affiliation: >-
+      Department of Chemical Engineering, Massachusetts
+      Institute of Technology, Cambridge, MA, USA
+    family-names: Shin
+    given-names: Sungho
+    email: sushin@mit.edu
+cff-version: 1.2.0
+identifiers:
+  - description: arXiv preprint
+    type: other
+    value: 'arXiv:2307.16830'
+keywords:
+  - Nonlinear Optimization
+  - Julia
+  - Nonlinear Programming
+  - Automatic Differentiation
+  - GPU
+license: MIT
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+preferred-citation:
+  type: article
+  title: >-
+    Accelerating optimal power flow with GPUs: SIMD abstraction of
+    nonlinear programs and condensed-space interior-point methods
+  authors:
+    - family-names: Shin
+      given-names: Sungho
+    - family-names: Anitescu
+      given-names: Mihai
+    - family-names: Pacaud
+      given-names: François
+  journal: Electric Power Systems Research
+  volume: '236'
+  year: 2024
+  doi: 10.1016/j.epsr.2024.110651
+repository-code: 'https://github.com/madsuite-org/ExaModels.jl'
+title: >-
+  ExaModels.jl: An algebraic modeling and automatic differentiation
+  tool in Julia, specialized for SIMD abstraction of nonlinear programs
+type: software
+version: 0.12.0
+date-released: '2026-08-14'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-![Logo](full-logo.svg)
-
 *An [algebraic modeling](https://en.wikipedia.org/wiki/Algebraic_modeling_language) and [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) tool in [Julia Language](https://julialang.org/), specialized for [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) abstraction of [nonlinear programs](https://en.wikipedia.org/wiki/Nonlinear_programming).*
 
----
-
-| **License** | **Documentation** | **Build Status** | **Coverage** | **Citation** |
-|:-----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
-| [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/madsuite-org/ExaModels.jl/blob/main/LICENSE) | [![doc](https://img.shields.io/badge/docs-stable-blue.svg)](https://madsuite-org.github.io/ExaModels.jl/stable) [![doc](https://img.shields.io/badge/docs-dev-blue.svg)](https://madsuite-org.github.io/ExaModels.jl/dev)  | [![build](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml) | [![codecov](https://codecov.io/gh/madsuite-org/ExaModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/madsuite-org/ExaModels.jl) | [![arXiv](https://img.shields.io/badge/arXiv-2307.16830-b31b1b.svg)](https://arxiv.org/abs/2307.16830) |
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/madsuite-org/ExaModels.jl/blob/main/LICENSE)
+[![docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://madsuite-org.github.io/ExaModels.jl/stable)
+[![docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://madsuite-org.github.io/ExaModels.jl/dev)
+[![build](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/madsuite-org/ExaModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/madsuite-org/ExaModels.jl)
+[![release](https://img.shields.io/github/v/release/madsuite-org/ExaModels.jl)](https://github.com/madsuite-org/ExaModels.jl/releases)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ExaModels.jl
+
 *An [algebraic modeling](https://en.wikipedia.org/wiki/Algebraic_modeling_language) and [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) tool in [Julia Language](https://julialang.org/), specialized for [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) abstraction of [nonlinear programs](https://en.wikipedia.org/wiki/Nonlinear_programming).*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/madsuite-org/ExaModels.jl/blob/main/LICENSE)


### PR DESCRIPTION
Per request: a `CITATION.cff` in [NLPModels.jl's style](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/blob/main/CITATION.cff) — Sungho Shin as the author, the EPSR article as `preferred-citation` with DOI/volume matching the README's bibtex, v0.12.0 as the released version — and the README header rebuilt: logo gone, badge table gone, six badges in one series (license · docs stable · docs dev · CI · codecov · release). The tagline stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)