### PR TITLE
Cite the ExaModels.jl paper (arXiv:2608.16265)

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -7,13 +7,3 @@
   primaryClass  = {math.OC},
   doi     = {10.48550/arXiv.2608.16265}
 }
-
-@article{shin2024accelerating,
-  title={Accelerating optimal power flow with {GPU}s: {SIMD} abstraction of nonlinear programs and condensed-space interior-point methods},
-  author={Shin, Sungho and Anitescu, Mihai and Pacaud, Fran{\c{c}}ois},
-  journal={Electric Power Systems Research},
-  volume={236},
-  pages={110651},
-  year={2024},
-  publisher={Elsevier}
-}

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,3 +1,13 @@
+@misc{shin2026examodels,
+  title   = {{ExaModels.jl}: An Algebraic Modeling System for Nonlinear Programming on {GPUs}},
+  author  = {Shin, Sungho and Schanen, Michel and Pacaud, Fran\c{c}ois and Montoison, Alexis and Anitescu, Mihai},
+  year    = {2026},
+  eprint  = {2608.16265},
+  archivePrefix = {arXiv},
+  primaryClass  = {math.OC},
+  doi     = {10.48550/arXiv.2608.16265}
+}
+
 @article{shin2024accelerating,
   title={Accelerating optimal power flow with {GPU}s: {SIMD} abstraction of nonlinear programs and condensed-space interior-point methods},
   author={Shin, Sungho and Anitescu, Mihai and Pacaud, Fran{\c{c}}ois},

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ cff-version: 1.2.0
 identifiers:
   - description: arXiv preprint
     type: other
-    value: 'arXiv:2307.16830'
+    value: 'arXiv:2608.16265'
 keywords:
   - Nonlinear Optimization
   - Julia
@@ -26,19 +26,22 @@ message: >-
 preferred-citation:
   type: article
   title: >-
-    Accelerating optimal power flow with GPUs: SIMD abstraction of
-    nonlinear programs and condensed-space interior-point methods
+    ExaModels.jl: An Algebraic Modeling System for Nonlinear
+    Programming on GPUs
   authors:
     - family-names: Shin
       given-names: Sungho
-    - family-names: Anitescu
-      given-names: Mihai
+    - family-names: Schanen
+      given-names: Michel
     - family-names: Pacaud
       given-names: François
-  journal: Electric Power Systems Research
-  volume: '236'
-  year: 2024
-  doi: 10.1016/j.epsr.2024.110651
+    - family-names: Montoison
+      given-names: Alexis
+    - family-names: Anitescu
+      given-names: Mihai
+  year: 2026
+  doi: 10.48550/arXiv.2608.16265
+  url: 'https://arxiv.org/abs/2608.16265'
 repository-code: 'https://github.com/madsuite-org/ExaModels.jl'
 title: >-
   ExaModels.jl: An algebraic modeling and automatic differentiation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![build](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml/badge.svg)](https://github.com/madsuite-org/ExaModels.jl/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/madsuite-org/ExaModels.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/madsuite-org/ExaModels.jl)
 [![release](https://img.shields.io/github/v/release/madsuite-org/ExaModels.jl)](https://github.com/madsuite-org/ExaModels.jl/releases)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.16265-b31b1b.svg)](https://arxiv.org/abs/2608.16265)
 
 ## Overview
 
@@ -55,7 +56,22 @@ reference implementation:
 
 ## Citation
 
-If you use ExaModels.jl in your research, please cite:
+If you use ExaModels.jl in your research, please cite the ExaModels.jl paper:
+
+```bibtex
+@misc{shin2026examodels,
+  title   = {{ExaModels.jl}: An Algebraic Modeling System for Nonlinear Programming on {GPUs}},
+  author  = {Shin, Sungho and Schanen, Michel and Pacaud, Fran\c{c}ois and Montoison, Alexis and Anitescu, Mihai},
+  year    = {2026},
+  eprint  = {2608.16265},
+  archivePrefix = {arXiv},
+  primaryClass  = {math.OC},
+  doi     = {10.48550/arXiv.2608.16265}
+}
+```
+
+The SIMD abstraction, and the condensed-space interior-point method it is paired with, are
+described in:
 
 ```bibtex
 @article{shin2024accelerating,

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ reference implementation:
 
 ## Citation
 
-If you use ExaModels.jl in your research, please cite the ExaModels.jl paper:
+If you use ExaModels.jl in your research, please cite:
 
 ```bibtex
 @misc{shin2026examodels,
@@ -67,21 +67,6 @@ If you use ExaModels.jl in your research, please cite the ExaModels.jl paper:
   archivePrefix = {arXiv},
   primaryClass  = {math.OC},
   doi     = {10.48550/arXiv.2608.16265}
-}
-```
-
-The SIMD abstraction, and the condensed-space interior-point method it is paired with, are
-described in:
-
-```bibtex
-@article{shin2024accelerating,
-  title   = {Accelerating optimal power flow with {GPUs}: {SIMD} abstraction of nonlinear programs and condensed-space interior-point methods},
-  author  = {Shin, Sungho and Anitescu, Mihai and Pacaud, Fran\c{c}ois},
-  journal = {Electric Power Systems Research},
-  volume  = {236},
-  pages   = {110651},
-  year    = {2024},
-  doi     = {10.1016/j.epsr.2024.110651}
 }
 ```
 


### PR DESCRIPTION
The ExaModels.jl paper is on arXiv as of 17 August 2026:

> **ExaModels.jl: An Algebraic Modeling System for Nonlinear Programming on GPUs**
> Sungho Shin, Michel Schanen, François Pacaud, Alexis Montoison, Mihai Anitescu
> [arXiv:2608.16265](https://arxiv.org/abs/2608.16265) · [doi:10.48550/arXiv.2608.16265](https://doi.org/10.48550/arXiv.2608.16265)

This adds it as the citation for the package, and keeps the 2024 *Electric Power Systems Research* article as the reference for the SIMD abstraction and the condensed-space interior-point method rather than as the thing to cite for the software itself.